### PR TITLE
Document OpenAI credential testing workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.2] - 2025-10-16
+
+### Documentation
+- Added a maintainer guide for running the OpenAI health check locally with private credentials and sharing sanitized results. (See `docs/2025-10-16-openai-credential-testing-guide.md`).
+- Captured the credential-handling plan so contributors know why tests remain manual when API keys cannot be shared in chat.
+
 ## [Version 0.4.1] - 2025-10-15
 
 ### Fixed

--- a/docs/2025-10-16-openai-credential-testing-guide.md
+++ b/docs/2025-10-16-openai-credential-testing-guide.md
@@ -1,0 +1,46 @@
+* Author: gpt-5-codex
+* Date: 2025-10-16 17:52 UTC
+* PURPOSE: Document how maintainers can run OpenAI provider verification locally without sharing credentials with the agent.
+* SRP/DRY check: Pass - provides a single source of truth for OpenAI health-check setup without overlapping other testing docs.
+
+# OpenAI Credential & Test Execution Guide
+
+This guide explains how to run the OpenAI health check locally while keeping your API key private. Follow these steps whenever you need to verify the provider after updates to `server/providers/openai.ts`.
+
+## 1. Prepare Your Environment
+- Ensure dependencies are installed: `npm install`
+- Create or update your `.env` file in the project root with the following entry:
+  ```env
+  OPENAI_API_KEY=sk-...
+  ```
+- Never paste or transmit the real key in chat or commit history.
+
+## 2. Run the Targeted Health Check
+Use the existing health-check script so we exercise the same path the server uses in production:
+```bash
+npm run health-check:openai
+```
+This command will:
+- Load environment variables via `dotenv`
+- Instantiate `OpenAIProvider`
+- Issue a lightweight Responses API request for a sanity check
+- Report latency and token usage details in the console
+
+## 3. Share Sanitized Results
+If you need assistance interpreting results:
+1. Copy the console output **without** the raw request/response payloads or any bearer tokens.
+2. Remove any references to secret environment paths.
+3. Share the sanitized log snippet in chat so we can debug together.
+
+## 4. Troubleshooting Checklist
+- Confirm the `.env` file is being loaded (the script logs missing key warnings).
+- Double-check that the model ID in the log matches one of the entries in `OpenAIProvider.models`.
+- Ensure your network allows outbound traffic to `api.openai.com`.
+- Retry with `DEBUG_SAVE_RAW=true` set in `.env` if deeper logs are required (files stay on your machine).
+
+## 5. When to Re-run the Check
+- After modifying `server/providers/openai.ts`
+- After changing environment variables related to OpenAI
+- Before deploying a new release that relies on OpenAI functionality
+
+By keeping the credential on your machine and only sharing sanitized logs, we stay secure while still validating the fix.

--- a/docs/2025-10-16-plan-openai-api-restoration.md
+++ b/docs/2025-10-16-plan-openai-api-restoration.md
@@ -1,0 +1,29 @@
+* Author: gpt-5-codex
+* Date: 2025-10-16 00:00 UTC
+* PURPOSE: Outline investigation steps and remediation tasks to restore OpenAI API traffic after Responses API refactor.
+* SRP/DRY check: Pass - single planning document referencing existing implementation guides in docs/ without duplicating logic.
+
+## Goal
+Re-establish OpenAI Responses API calls so user requests reach OpenAI again after the refactor regression.
+
+## Current Understanding
+- Provider refactor now routes all OpenAI calls through `server/providers/openai.ts`.
+- Reports indicate no traffic reaches OpenAI despite valid API keys across environments.
+- Recent refactor introduced new message-to-prompt conversion and streaming payload builder; likely mismatch with Responses API contract.
+
+## Investigation Tasks
+1. Review `OpenAIProvider` request construction to confirm `input` payload matches Responses API schema (role/content objects with text parts).
+2. Verify reasoning configuration only applies to models that actually expose reasoning; avoid sending unsupported parameters that short-circuit the SDK.
+3. Inspect streaming path to ensure it reuses the same payload construction and does not bypass fixes from (1).
+4. Audit logging/return values for `systemPrompt` to retain observability after payload adjustments.
+
+## Remediation Plan
+- Implement a helper that converts `ModelMessage[]` plus optional system prompt into both structured Responses input and human-readable prompt string.
+- Update non-streaming and streaming calls to use the helper, including temperature/max token handling.
+- Gate reasoning metadata on model capabilities to prevent client-side validation failure.
+- Keep retry/timeout behavior unchanged while ensuring partial responses still propagate through callbacks.
+
+## Validation Steps
+- Run targeted unit/integration checks locally if available (e.g., `npm run health-check:openai` with stubbed API key) to confirm request dispatch.
+- Perform manual smoke test against staging with valid credentials to confirm OpenAI usage logs populate again.
+- Monitor logs for reasoning/streaming callbacks to ensure no regression in SSE delivery.

--- a/docs/2025-10-16-plan-openai-credential-handoff.md
+++ b/docs/2025-10-16-plan-openai-credential-handoff.md
@@ -1,0 +1,22 @@
+* Author: gpt-5-codex
+* Date: 2025-10-16 17:50 UTC
+* PURPOSE: Define next steps for documenting secure credential handling and ensuring OpenAI verification flows stay testable without sharing secrets.
+* SRP/DRY check: Pass - focused on planning tasks for credential guidance without duplicating execution docs that live elsewhere.
+
+## Goal
+Provide clear guidance for running OpenAI provider verification without transmitting credentials to the agent, and capture follow-up work for changelog updates.
+
+## Current Context
+- Previous remediation ensured Responses API payloads are schema-compliant, but regression testing still requires valid OpenAI credentials.
+- User cannot share secrets through this interface; we must document how they can run checks locally.
+- Changelog lacks an entry explaining the documentation guidance and current validation expectations.
+
+## Tasks
+1. Draft a credential-handling and test execution guide so maintainers can run `npm run health-check:openai` locally with their own `.env` values.
+2. Update the changelog with a documentation entry summarizing the new guidance and reiterating that tests must be run locally with valid keys.
+3. Confirm no code changes are necessary and communicate the testing limitation and instructions back to the user.
+
+## Validation
+- Ensure documentation explicitly states that credentials should stay local and highlights required environment variables and commands.
+- Verify changelog reflects the documentation addition and indicates manual validation steps.
+- Provide the user with a concise explanation of how to configure their environment and share sanitized test output if desired.


### PR DESCRIPTION
## Summary
- capture the follow-up plan for handling OpenAI credential-sensitive testing outside the chat interface
- document maintainer instructions for running the OpenAI health check locally with private keys and sharing sanitized logs
- update the changelog with the new documentation entry so the release history reflects the guidance

## Testing
- not run (OpenAI credentials required)

------
https://chatgpt.com/codex/tasks/task_e_68f12c0c46848326aabe286d8728e53b