### PR TITLE
Refactor OpenAI Responses API usage

### DIFF
--- a/docs/2025-10-16-plan-openai-responses-fixes.md
+++ b/docs/2025-10-16-plan-openai-responses-fixes.md
@@ -1,0 +1,36 @@
+<!--
+ * Author: gpt-5-codex
+ * Date: 2025-10-16 18:34 UTC
+ * PURPOSE: Outline the implementation plan to correct OpenAI Responses API usage, covering message formatting, streaming events, reasoning config, and documentation updates to align with official references.
+ * SRP/DRY check: Pass - Plan file only aggregates tasks related to the Responses API fixes without duplicating existing documentation.
+-->
+# Plan: OpenAI Responses API Critical Fixes
+
+## Goal
+Restore compliance with the OpenAI Responses API so that both streaming and non-streaming flows operate per October 2025 reference implementations, eliminating incorrect event handling and message formatting.
+
+## Tasks
+1. **Update type definitions**
+   - Extend `ModelMessage` to support the `developer` role.
+   - Add `instructions`, `previousResponseId`, and reasoning config fields to `CallOptions` / streaming options.
+2. **Refactor OpenAI provider non-streaming flow**
+   - Map `ModelMessage[]` directly to Responses API message objects.
+   - Include new request parameters (`instructions`, `previous_response_id`, `store`).
+   - Simplify response parsing to rely on `output_text` and `output_reasoning`.
+3. **Refactor streaming flow**
+   - Replace deprecated event names with `response.output_text.delta` and `response.done`.
+   - Capture reasoning summary from `response.done` events.
+   - Compute usage/cost from final response metadata.
+4. **Cleanup reasoning configuration**
+   - Remove `text.verbosity` usage and default to `{ summary: 'auto' }` when applicable.
+   - Only attach `reasoning` settings for models that support it.
+5. **Validation**
+   - Run targeted TypeScript type check if feasible.
+   - Verify updated logic compiles and integrates with existing provider architecture.
+
+## Risks & Mitigations
+- **SDK surface changes**: If the OpenAI SDK types differ, cast payloads to `any` where needed with clear comments.
+- **Downstream dependencies**: Adjust return payloads carefully to avoid breaking consumers expecting `systemPrompt` or `responseId` fields.
+
+## Expected Outcome
+A corrected OpenAI provider that matches official Responses API behavior, supporting conversation chaining, reasoning summaries, and accurate streaming events without legacy artifacts.

--- a/server/providers/base.ts
+++ b/server/providers/base.ts
@@ -1,9 +1,12 @@
-/**
- * Base Provider Interface
- * 
- * Defines the common interface for all AI providers
- * Author: Replit Agent
- * Date: August 9, 2025
+/*
+ * Author: gpt-5-codex
+ * Date: 2025-10-16 18:34 UTC
+ * PURPOSE: Declares shared provider contracts, including model metadata, message roles, and
+ *          invocation option shapes leveraged by all providers. Updated to expose the developer
+ *          role, instructions steering, conversation chaining, and reasoning configuration options
+ *          required for the Responses API fixes.
+ * SRP/DRY check: Pass - File centralizes provider type definitions without duplicating logic from
+ *                concrete provider implementations.
  */
 
 export interface ModelConfig {
@@ -66,7 +69,7 @@ export interface ModelResponse {
  */
 export interface ModelMessage {
   /** Message role - system for instructions, user for queries, context for additional info */
-  role: 'system' | 'user' | 'assistant' | 'context';
+  role: 'system' | 'user' | 'assistant' | 'context' | 'developer';
   /** The actual message content */
   content: string;
   /** Optional metadata for message tracking and processing */
@@ -84,6 +87,15 @@ export interface CallOptions {
   maxTokens?: number;
   /** Legacy system prompt (prefer structured messages) */
   systemPrompt?: string;
+  /** Responses API instructions field for high-priority steering */
+  instructions?: string;
+  /** Continue a stored conversation by referencing the previous response id */
+  previousResponseId?: string;
+  /** Fine-grained reasoning configuration for capable models */
+  reasoningConfig?: {
+    effort?: 'low' | 'medium' | 'high';
+    summary?: 'auto' | 'detailed';
+  };
 }
 
 export interface StreamingCallbacks {
@@ -101,10 +113,11 @@ export interface StreamingCallOptions {
   maxTokens?: number;
   // Reasoning configuration for advanced models
   reasoningConfig?: {
-    effort?: 'minimal' | 'low' | 'medium' | 'high';
-    summary?: 'auto' | 'detailed' | 'concise';
-    verbosity?: 'low' | 'medium' | 'high';
+    effort?: 'low' | 'medium' | 'high';
+    summary?: 'auto' | 'detailed';
   };
+  /** Optional Responses API instructions steering */
+  instructions?: string;
   onReasoningChunk: (chunk: string) => void;
   onContentChunk: (chunk: string) => void;
   onComplete: (responseId: string, tokenUsage: any, cost: any, content?: string, reasoning?: string) => void;

--- a/server/routes/debate.routes.ts
+++ b/server/routes/debate.routes.ts
@@ -1,8 +1,11 @@
 /*
- * Author: Cascade
- * Date: October 14, 2025 and 7:23pm UTC-04:00
- * PURPOSE: This routes file handles debate streaming endpoints, including turn-based debate logic with reasoning and content streaming. It integrates with providers for streaming model responses.
- * SRP/DRY check: Pass - Focused solely on debate logic. Debate patterns were repeated in the monolithic routes.ts; this extracts them. Reviewed existing debate code to ensure no duplication.
+ * Author: gpt-5-codex
+ * Date: 2025-10-16 18:34 UTC
+ * PURPOSE: Updates debate streaming routes to align with corrected Responses API options by
+ *          removing deprecated verbosity controls and relying on provider-level reasoning defaults
+ *          while preserving existing debate session orchestration.
+ * SRP/DRY check: Pass - File continues to focus on debate routing concerns without duplicating
+ *                provider logic.
  */
 import { Router, Request, Response } from "express";
 import { getProviderForModel } from "../providers/index.js";
@@ -95,8 +98,7 @@ router.post("/stream", async (req, res) => {
       turnNumber, // 1-10
       // New configuration parameters
       reasoningEffort = 'medium',
-      reasoningSummary = 'detailed',
-      textVerbosity = 'high',
+      reasoningSummary = 'auto',
       temperature = 0.7,
       maxTokens = 16384,
       // Session management
@@ -225,8 +227,7 @@ Respond as the ${role} debater:
       // Reasoning configuration for OpenAI provider
       reasoningConfig: {
         effort: reasoningEffort,
-        summary: reasoningSummary,
-        verbosity: textVerbosity
+        summary: reasoningSummary
       },
       onReasoningChunk: (chunk: string) => {
         res.write(`event: stream.chunk\ndata: ${JSON.stringify({


### PR DESCRIPTION
## Summary
- extend shared provider contracts with the developer role plus instructions and conversation chaining options required by the Responses API
- refactor the OpenAI provider to send structured message arrays, honor instructions/previous responses, and process the correct streaming events while simplifying reasoning configuration
- adjust debate streaming routes to drop deprecated verbosity settings and document the remediation plan for these Responses API fixes

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated Luigi/auth files)*

------
https://chatgpt.com/codex/tasks/task_e_68f13a700e108326b433b8a9ca70118b