### PR TITLE
Align OpenAI provider with Responses API contract

### DIFF
--- a/docs/2025-10-16-plan-openai-responses-refactor.md
+++ b/docs/2025-10-16-plan-openai-responses-refactor.md
@@ -1,0 +1,44 @@
+<!--
+ * Author: gpt-5-codex
+ * Date: 2025-10-16 18:40 UTC
+ * PURPOSE: Document today's objectives and ordered tasks for aligning the OpenAI provider with the Responses API specification.
+ * SRP/DRY check: Pass - planning document consolidates scope without duplicating existing docs.
+-->
+
+# Plan: OpenAI Responses API Corrections
+
+## Goal
+Bring `OpenAIProvider` into parity with the October 2025 Responses API expectations and update shared types so conversation metadata and steering options are supported consistently.
+
+## Context
+The current provider still converts messages into a flattened prompt, relies on invalid streaming events, and lacks support for new parameters like `instructions` and `previous_response_id`. Fixing these requires coordinated changes in both the base provider types and the OpenAI provider implementation.
+
+## Tasks
+1. **Update shared provider interfaces**
+   - Add `developer` role support to `ModelMessage`.
+   - Extend `CallOptions` with `instructions`, `previousResponseId`, and optional reasoning configuration for parity with streaming options.
+   - Refresh header comment to repository standard.
+2. **Refactor OpenAI provider request builders**
+   - Replace prompt concatenation with direct message arrays and map custom roles.
+   - Support optional `instructions`, `temperature`, and conversation chaining for both streaming and non-streaming calls.
+   - Simplify reasoning defaults to `auto` summary and remove undocumented verbosity control.
+3. **Correct streaming event handling**
+   - Switch to the documented `response.output_text.delta` and `response.done` events.
+   - Accumulate reasoning from the final response payload.
+   - Ensure cost calculation uses provided usage stats.
+4. **Tighten response parsing**
+   - Trust `response.output_text` for text output while still exposing IDs and usage for downstream consumers.
+   - Maintain compatibility with existing cost/reporting fields.
+5. **Validation**
+   - Run `npm run check` to confirm updated types compile across the project.
+
+## Risks & Mitigations
+- **SDK typings drift**: Use defensive optional chaining when reading new properties to avoid runtime crashes.
+- **Downstream expectations**: Preserve `systemPrompt` output by deriving a readable trace from normalized messages.
+- **Streaming interface changes**: Keep callbacks intact and surface errors promptly through `onError`.
+
+## Success Criteria
+- Requests send structured message arrays with accurate roles.
+- Streaming callbacks receive text via `response.output_text.delta` events.
+- Non-streaming responses expose reasoning summaries when present.
+- TypeScript compilation succeeds without consumers needing updates.

--- a/server/providers/base.ts
+++ b/server/providers/base.ts
@@ -1,9 +1,10 @@
-/**
- * Base Provider Interface
- * 
- * Defines the common interface for all AI providers
- * Author: Replit Agent
- * Date: August 9, 2025
+/*
+ * Author: gpt-5-codex
+ * Date: 2025-10-16 18:45 UTC
+ * PURPOSE: Define shared provider contracts, message roles, and streaming callbacks for all AI integrations.
+ *          Updated to add developer-role steering and Responses API specific options such as instructions
+ *          and conversation chaining metadata so downstream providers can support them consistently.
+ * SRP/DRY check: Pass - centralizes provider interfaces without duplicating logic contained in subclasses.
  */
 
 export interface ModelConfig {
@@ -65,8 +66,8 @@ export interface ModelResponse {
  * Enables proper role separation for advanced prompt engineering
  */
 export interface ModelMessage {
-  /** Message role - system for instructions, user for queries, context for additional info */
-  role: 'system' | 'user' | 'assistant' | 'context';
+  /** Message role - includes developer for high-priority steering and context remapped to system */
+  role: 'system' | 'user' | 'assistant' | 'context' | 'developer';
   /** The actual message content */
   content: string;
   /** Optional metadata for message tracking and processing */
@@ -84,6 +85,16 @@ export interface CallOptions {
   maxTokens?: number;
   /** Legacy system prompt (prefer structured messages) */
   systemPrompt?: string;
+  /** Responses API instructions parameter for high-priority steering */
+  instructions?: string;
+  /** Previous response identifier to enable conversation chaining */
+  previousResponseId?: string;
+  /** Optional reasoning configuration for compatible models */
+  reasoningConfig?: {
+    effort?: 'minimal' | 'low' | 'medium' | 'high';
+    summary?: 'auto' | 'detailed' | 'concise';
+    verbosity?: 'low' | 'medium' | 'high';
+  };
 }
 
 export interface StreamingCallbacks {
@@ -103,7 +114,6 @@ export interface StreamingCallOptions {
   reasoningConfig?: {
     effort?: 'minimal' | 'low' | 'medium' | 'high';
     summary?: 'auto' | 'detailed' | 'concise';
-    verbosity?: 'low' | 'medium' | 'high';
   };
   onReasoningChunk: (chunk: string) => void;
   onContentChunk: (chunk: string) => void;


### PR DESCRIPTION
## Summary
- add plan document outlining the Responses API remediation tasks
- extend shared provider types with developer-role messages, instructions, and conversation chaining metadata
- refactor the OpenAI provider to send structured message arrays, support instructions/previous responses, and process the documented streaming events

## Testing
- npm run check *(fails: pre-existing TypeScript errors in Luigi components, storage, and other providers)*

------
https://chatgpt.com/codex/tasks/task_e_68f13a700e108326b433b8a9ca70118b