### PR TITLE
Fix OpenAI reasoning stream compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.3] - 2025-10-16
+
+### Fixed
+- **OpenAI Responses API Compliance:** Defaulted GPT-5 reasoning requests to detailed summaries with high verbosity, kept o-series models within supported parameters, and aligned debate streaming defaults with the richer configuration surface.
+- **Streaming Lifecycle Overhaul:** Adopted the SDK's `responses.stream` helper, handled reasoning summary deltas, and finalized streams via `finalResponse()` so callbacks receive complete content, reasoning, and token usage.
+- **Output Extraction Reliability:** Normalized non-streaming and streaming completions to read from `output_text`, `output_parsed`, or `output[]`, preventing empty transcripts when models emit structured results.
+
 ## [Version 0.4.2] - 2025-10-16
 
 ### Documentation

--- a/docs/2025-10-16-plan-openai-responses.md
+++ b/docs/2025-10-16-plan-openai-responses.md
@@ -1,0 +1,43 @@
+<!--
+ * Author: gpt-5-codex
+ * Date: 2025-10-16 20:35 UTC
+ * PURPOSE: Document the step-by-step remediation plan for fixing the OpenAI Responses API
+ *          integration bugs, covering reasoning parameter defaults, streaming adoption,
+ *          output extraction, and changelog updates across server providers and routes.
+ * SRP/DRY check: Pass - Focused solely on capturing today's plan without duplicating
+ *                code-level logic stored elsewhere in the repository.
+-->
+# Plan: Responses API Streaming Remediation
+
+## Goals
+- Restore compliant usage of the OpenAI Responses API for GPT-5 and o-series reasoning models.
+- Capture real-time reasoning streams with the required verbosity settings.
+- Ensure non-streaming calls correctly handle all response output shapes.
+- Align debate streaming routes and shared types with the updated configuration surface.
+- Record the release in the changelog with an appropriate semantic version bump.
+
+## Tasks
+1. **Type Updates**
+   - Extend `CallOptions` and `StreamingCallOptions` reasoning config to carry verbosity controls.
+   - Confirm shared provider contracts remain SRP compliant after the extension.
+2. **Provider Fixes**
+   - Update `callModel` to default reasoning summary to `detailed` for GPT-5/o-models and inject `text.verbosity`.
+   - Migrate `callModelStreaming` to `openai.responses.stream`, handle all SSE event variants, and use `finalResponse()` for completion metadata.
+   - Extract output parsing into a reusable helper that accounts for `output_text`, `output_parsed`, and `output[]` blocks.
+3. **Route Adjustments**
+   - Default debate streaming API payloads to `reasoningSummary = 'detailed'` and `reasoningVerbosity = 'high'`.
+   - Forward optional verbosity overrides through to the provider call.
+4. **Changelog**
+   - Add a new semantic version entry at the top of `CHANGELOG.md` summarizing the fixes.
+5. **Verification**
+   - Run targeted TypeScript checks or relevant tests to ensure type safety.
+   - Review diffs for compliance with AGENTS instructions before committing.
+
+## Open Questions
+- Confirm whether any other routes (e.g., analysis streaming) need matching verbosity defaults.
+- Validate if o3/o4 models require alternative reasoning payloads beyond summary defaults.
+
+## Next Steps
+- Implement type and provider changes.
+- Update routes and changelog.
+- Execute verification commands and prepare PR summary.

--- a/server/providers/base.ts
+++ b/server/providers/base.ts
@@ -95,6 +95,7 @@ export interface CallOptions {
   reasoningConfig?: {
     effort?: 'low' | 'medium' | 'high';
     summary?: 'auto' | 'detailed';
+    verbosity?: 'low' | 'medium' | 'high';
   };
 }
 
@@ -115,6 +116,7 @@ export interface StreamingCallOptions {
   reasoningConfig?: {
     effort?: 'low' | 'medium' | 'high';
     summary?: 'auto' | 'detailed';
+    verbosity?: 'low' | 'medium' | 'high';
   };
   /** Optional Responses API instructions steering */
   instructions?: string;

--- a/server/routes/debate.routes.ts
+++ b/server/routes/debate.routes.ts
@@ -98,7 +98,8 @@ router.post("/stream", async (req, res) => {
       turnNumber, // 1-10
       // New configuration parameters
       reasoningEffort = 'medium',
-      reasoningSummary = 'auto',
+      reasoningSummary = 'detailed',
+      reasoningVerbosity = 'high',
       temperature = 0.7,
       maxTokens = 16384,
       // Session management
@@ -227,7 +228,8 @@ Respond as the ${role} debater:
       // Reasoning configuration for OpenAI provider
       reasoningConfig: {
         effort: reasoningEffort,
-        summary: reasoningSummary
+        summary: reasoningSummary,
+        verbosity: reasoningVerbosity
       },
       onReasoningChunk: (chunk: string) => {
         res.write(`event: stream.chunk\ndata: ${JSON.stringify({


### PR DESCRIPTION
## Summary
- document the remediation plan for restoring OpenAI Responses API compliance.
- extend provider contracts and debate routing defaults to surface reasoning verbosity controls.
- harden the OpenAI provider for reasoning models by using `responses.stream`, richer event handling, and resilient output extraction; record the release in the changelog.

## Testing
- `npm run check` *(fails: repository already contains unrelated TypeScript errors across Luigi, auth, and provider files).*

------
https://chatgpt.com/codex/tasks/task_e_68f1558f1aec8326a18020938e21cd37