### PR TITLE
Add debate reasoning timeline replay drawer

### DIFF
--- a/client/src/components/MessageCard.tsx
+++ b/client/src/components/MessageCard.tsx
@@ -22,7 +22,7 @@
  * Date: August 11, 2025
  */
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -76,15 +76,17 @@ interface MessageCardProps {
   showFooter?: boolean;
   className?: string;
   seatColor?: string; // For battle-chat mode seat colors
+  footerActions?: ReactNode;
 }
 
-export function MessageCard({ 
-  message, 
+export function MessageCard({
+  message,
   variant = 'default',
   showHeader = true,
   showFooter = true,
   className = '',
-  seatColor 
+  seatColor,
+  footerActions
 }: MessageCardProps) {
   const { toast } = useToast();
   const [isCopying, setIsCopying] = useState(false);
@@ -314,16 +316,19 @@ export function MessageCard({
               )}
             </div>
             
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={copyToClipboard}
-              disabled={isCopying}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-3 py-2 h-8 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors"
-            >
-              <Copy className="w-4 h-4 mr-2" />
-              <span className="text-sm font-medium">{isCopying ? 'Copied!' : 'Copy'}</span>
-            </Button>
+            <div className="flex items-center space-x-2">
+              {footerActions}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={copyToClipboard}
+                disabled={isCopying}
+                className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-3 py-2 h-8 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors"
+              >
+                <Copy className="w-4 h-4 mr-2" />
+                <span className="text-sm font-medium">{isCopying ? 'Copied!' : 'Copy'}</span>
+              </Button>
+            </div>
           </div>
         )}
       </CardContent>

--- a/client/src/components/debate/DebateMessageCard.tsx
+++ b/client/src/components/debate/DebateMessageCard.tsx
@@ -1,0 +1,361 @@
+/*
+ * Author: GPT-5 Codex
+ * Date: 2025-10-17 19:18 UTC
+ * PURPOSE: Wrap MessageCard with a debate-specific log drawer that replays reasoning chunks and analytics.
+ * SRP/DRY check: Pass - Component coordinates debate message presentation and log replay without owning session state.
+ */
+
+import { useMemo, useState } from 'react';
+import { MessageCard, type MessageCardData } from '@/components/MessageCard';
+import { ReasoningTimeline } from '@/components/debate/ReasoningTimeline';
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { Flame, Link as LinkIcon, FileText, Coins } from 'lucide-react';
+import type { DebateMessage } from '@/hooks/useDebateSession';
+import type { AIModel } from '@/types/ai-models';
+import { computeInflectionThreshold, weightChunks } from '@/lib/chunkAnalytics';
+import type { ContentStreamChunk, ReasoningStreamChunk } from '@/hooks/useAdvancedStreaming';
+
+interface DebateMessageCardProps {
+  message: DebateMessage;
+  models: AIModel[];
+  seatColor?: string;
+  opponentMessages: DebateMessage[];
+}
+
+interface ChunkInsight<T extends ContentStreamChunk | ReasoningStreamChunk> {
+  chunk: T;
+  estimatedTokens: number;
+  estimatedCost: number;
+  cumulativeTokens: number;
+  cumulativeCost: number;
+  isInflection: boolean;
+  opponentReference?: DebateMessage;
+}
+
+const toMessageCardData = (
+  message: DebateMessage,
+  models: AIModel[]
+): MessageCardData => {
+  const model = models.find(m => m.id === message.modelId);
+  return {
+    id: message.id,
+    modelName: message.modelName,
+    modelId: message.modelId,
+    content: message.content,
+    reasoning: message.reasoning,
+    systemPrompt: message.systemPrompt,
+    responseTime: message.responseTime,
+    round: message.round,
+    timestamp: message.timestamp,
+    type: 'debate',
+    tokenUsage: message.tokenUsage,
+    cost: message.cost,
+    modelConfig: {
+      provider: model?.provider,
+      capabilities: message.modelConfig?.capabilities || {
+        reasoning: !!message.reasoning,
+        multimodal: false,
+        functionCalling: false,
+        streaming: true
+      },
+      pricing: message.modelConfig?.pricing
+    }
+  };
+};
+
+const selectOpponentReference = (chunkTimestamp: number, opponentMessages: DebateMessage[]): DebateMessage | undefined => {
+  return opponentMessages.reduce<DebateMessage | undefined>((closest, candidate) => {
+    if (candidate.timestamp > chunkTimestamp) {
+      return closest;
+    }
+    if (!closest) {
+      return candidate;
+    }
+    return candidate.timestamp > closest.timestamp ? candidate : closest;
+  }, undefined);
+};
+
+const buildChunkInsights = <T extends ReasoningStreamChunk | ContentStreamChunk>(
+  chunks: T[],
+  totalTokens: number,
+  totalCost: number,
+  opponentMessages: DebateMessage[],
+  inflectionThreshold: number
+): ChunkInsight<T>[] => {
+  const weighted = weightChunks(chunks);
+  let runningTokens = 0;
+  let runningCost = 0;
+
+  return weighted.map(entry => {
+    const estimatedTokens = totalTokens * entry.weight;
+    const estimatedCost = totalCost * entry.weight;
+    runningTokens += estimatedTokens;
+    runningCost += estimatedCost;
+    return {
+      chunk: entry.chunk,
+      estimatedTokens,
+      estimatedCost,
+      cumulativeTokens: runningTokens,
+      cumulativeCost: runningCost,
+      isInflection: entry.chunk.intensity >= inflectionThreshold,
+      opponentReference: selectOpponentReference(entry.chunk.timestamp, opponentMessages)
+    };
+  });
+};
+
+const formatSeconds = (timestamp: number, base: number) => {
+  const elapsed = (timestamp - base) / 1000;
+  return `${elapsed.toFixed(2)}s`;
+};
+
+const formatTokenDelta = (value: number) => `${Math.round(value)}`;
+
+const formatCostDelta = (value: number) => `$${value.toFixed(4)}`;
+
+export function DebateMessageCard({
+  message,
+  models,
+  seatColor,
+  opponentMessages
+}: DebateMessageCardProps) {
+  const messageData = useMemo(() => toMessageCardData(message, models), [message, models]);
+  const reasoningChunks = message.reasoningChunks ?? [];
+  const contentChunks = message.contentChunks ?? [];
+
+  const opponentMessagesSorted = useMemo(
+    () => [...opponentMessages].sort((a, b) => a.timestamp - b.timestamp),
+    [opponentMessages]
+  );
+
+  const reasoningTokenTotal = message.tokenUsage?.reasoning ?? 0;
+  const outputTokenTotal = message.tokenUsage?.output ?? 0;
+  const reasoningCostTotal = message.cost?.reasoning ?? 0;
+  const contentCostTotal = Math.max((message.cost?.total ?? 0) - (message.cost?.reasoning ?? 0), 0);
+
+  const reasoningThreshold = useMemo(
+    () => computeInflectionThreshold(reasoningChunks),
+    [reasoningChunks]
+  );
+  const contentThreshold = useMemo(
+    () => computeInflectionThreshold(contentChunks),
+    [contentChunks]
+  );
+
+  const baseTimestamp = useMemo(() => {
+    const timestamps = [...reasoningChunks, ...contentChunks].map(chunk => chunk.timestamp);
+    return timestamps.length ? Math.min(...timestamps) : message.timestamp;
+  }, [reasoningChunks, contentChunks, message.timestamp]);
+
+  const reasoningInsights = useMemo(
+    () =>
+      buildChunkInsights(
+        reasoningChunks,
+        reasoningTokenTotal,
+        reasoningCostTotal,
+        opponentMessagesSorted,
+        reasoningThreshold
+      ),
+    [reasoningChunks, reasoningTokenTotal, reasoningCostTotal, opponentMessagesSorted, reasoningThreshold]
+  );
+
+  const contentInsights = useMemo(
+    () =>
+      buildChunkInsights(
+        contentChunks,
+        outputTokenTotal,
+        contentCostTotal,
+        opponentMessagesSorted,
+        contentThreshold
+      ),
+    [contentChunks, outputTokenTotal, contentCostTotal, opponentMessagesSorted, contentThreshold]
+  );
+
+  const [selectedTimestamp, setSelectedTimestamp] = useState<number | undefined>(undefined);
+
+  const handleChunkFocus = (timestamp: number) => {
+    setSelectedTimestamp(timestamp);
+  };
+
+  return (
+    <Drawer>
+      <MessageCard
+        message={messageData}
+        variant="detailed"
+        showHeader
+        showFooter
+        className="shadow-sm"
+        seatColor={seatColor}
+        footerActions={
+          (reasoningChunks.length > 0 || contentChunks.length > 0) && (
+            <DrawerTrigger asChild>
+              <Button size="sm" variant="outline" className="h-8 text-xs font-semibold">
+                <FileText className="mr-2 h-4 w-4" />
+                View Log
+              </Button>
+            </DrawerTrigger>
+          )
+        }
+      />
+
+      <DrawerContent className="max-h-[85vh]">
+        <DrawerHeader className="text-left">
+          <DrawerTitle className="flex items-center justify-between text-base">
+            <span>{message.modelName} · Turn {message.round}</span>
+            <Badge variant="outline" className="text-xs">
+              {new Date(message.timestamp).toLocaleTimeString()}
+            </Badge>
+          </DrawerTitle>
+          <DrawerDescription className="text-sm text-slate-600 dark:text-slate-300">
+            Replay the model's private reasoning alongside spoken output. Token and cost deltas are approximated via chunk
+            proportions to highlight expensive inflection points.
+          </DrawerDescription>
+        </DrawerHeader>
+
+        <div className="px-4 pb-4 space-y-6">
+          <ReasoningTimeline
+            reasoningChunks={reasoningChunks}
+            contentChunks={contentChunks}
+            selectedTimestamp={selectedTimestamp}
+            onScrub={setSelectedTimestamp}
+          />
+
+          <Separator />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-amber-700 dark:text-amber-300 flex items-center gap-2">
+                  <Flame className="h-4 w-4" />
+                  Reasoning Chunks
+                </h3>
+                <Badge variant="outline" className="text-xs">
+                  {reasoningInsights.length} steps
+                </Badge>
+              </div>
+              <ScrollArea className="h-72 rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/30 p-3">
+                <div className="space-y-3">
+                  {reasoningInsights.map((insight, index) => (
+                    <div
+                      key={`reasoning-${insight.chunk.timestamp}-${index}`}
+                      className={`rounded-md border px-3 py-2 text-xs shadow-sm transition-colors ${
+                        insight.isInflection
+                          ? 'border-amber-400/70 bg-amber-50 dark:border-amber-500/60 dark:bg-amber-900/20'
+                          : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                      }`}
+                      onMouseEnter={() => handleChunkFocus(insight.chunk.timestamp)}
+                    >
+                      <div className="flex items-center justify-between font-medium text-slate-600 dark:text-slate-200">
+                        <span>
+                          Step {index + 1} · {formatSeconds(insight.chunk.timestamp, baseTimestamp)}
+                        </span>
+                        <span className="font-mono text-slate-500 dark:text-slate-300">
+                          Δ{formatTokenDelta(insight.estimatedTokens)} tok · {formatCostDelta(insight.estimatedCost)}
+                        </span>
+                      </div>
+                      <p className="mt-2 whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-slate-700 dark:text-slate-100">
+                        {insight.chunk.delta.trim() || '…'}
+                      </p>
+                      {insight.opponentReference && (
+                        <a
+                          href={`#${insight.opponentReference.id}`}
+                          className="mt-2 inline-flex items-center text-[11px] font-semibold text-sky-600 hover:text-sky-700 dark:text-sky-300"
+                        >
+                          <LinkIcon className="mr-1 h-3 w-3" />
+                          Opponent: {insight.opponentReference.modelName} · Round {insight.opponentReference.round}
+                        </a>
+                      )}
+                    </div>
+                  ))}
+                  {reasoningInsights.length === 0 && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400">No reasoning telemetry captured for this turn.</p>
+                  )}
+                </div>
+              </ScrollArea>
+            </section>
+
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-sky-700 dark:text-sky-300 flex items-center gap-2">
+                  <Coins className="h-4 w-4" />
+                  Spoken Chunks
+                </h3>
+                <Badge variant="outline" className="text-xs">
+                  {contentInsights.length} segments
+                </Badge>
+              </div>
+              <ScrollArea className="h-72 rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/30 p-3">
+                <div className="space-y-3">
+                  {contentInsights.map((insight, index) => (
+                    <div
+                      key={`content-${insight.chunk.timestamp}-${index}`}
+                      className={`rounded-md border px-3 py-2 text-xs shadow-sm transition-colors ${
+                        insight.isInflection
+                          ? 'border-sky-400/70 bg-sky-50 dark:border-sky-500/60 dark:bg-sky-900/20'
+                          : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                      }`}
+                      onMouseEnter={() => handleChunkFocus(insight.chunk.timestamp)}
+                    >
+                      <div className="flex items-center justify-between font-medium text-slate-600 dark:text-slate-200">
+                        <span>
+                          Segment {index + 1} · {formatSeconds(insight.chunk.timestamp, baseTimestamp)}
+                        </span>
+                        <span className="font-mono text-slate-500 dark:text-slate-300">
+                          Δ{formatTokenDelta(insight.estimatedTokens)} tok · {formatCostDelta(insight.estimatedCost)}
+                        </span>
+                      </div>
+                      <p className="mt-2 whitespace-pre-wrap text-[11px] leading-relaxed text-slate-700 dark:text-slate-100">
+                        {insight.chunk.delta.trim() || '…'}
+                      </p>
+                      {insight.opponentReference && (
+                        <a
+                          href={`#${insight.opponentReference.id}`}
+                          className="mt-2 inline-flex items-center text-[11px] font-semibold text-sky-600 hover:text-sky-700 dark:text-sky-300"
+                        >
+                          <LinkIcon className="mr-1 h-3 w-3" />
+                          Responding to {insight.opponentReference.modelName}
+                        </a>
+                      )}
+                    </div>
+                  ))}
+                  {contentInsights.length === 0 && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400">No streamed content chunks recorded.</p>
+                  )}
+                </div>
+              </ScrollArea>
+            </section>
+          </div>
+        </div>
+
+        <DrawerFooter className="border-t border-slate-200 dark:border-slate-700">
+          <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-600 dark:text-slate-300">
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary" className="bg-amber-500/10 text-amber-700 dark:text-amber-200">
+                Reasoning Δ Tokens ≈ {formatTokenDelta(reasoningTokenTotal)}
+              </Badge>
+              <Badge variant="secondary" className="bg-sky-500/10 text-sky-700 dark:text-sky-200">
+                Output Δ Tokens ≈ {formatTokenDelta(outputTokenTotal)}
+              </Badge>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="font-semibold">Estimated cost mix:</span>
+              <span className="font-mono">{formatCostDelta(reasoningCostTotal)} reasoning</span>
+              <span className="font-mono">{formatCostDelta(contentCostTotal)} spoken</span>
+            </div>
+          </div>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/client/src/components/debate/DebateMessageList.tsx
+++ b/client/src/components/debate/DebateMessageList.tsx
@@ -1,53 +1,16 @@
-/**
- * Debate message list component for displaying debate exchanges
- *
- * Author: Cascade
- * Date: October 15, 2025
- * PURPOSE: Renders debate messages with proper formatting and continue buttons
- * SRP/DRY check: Pass - Single responsibility for message list rendering, no duplication with other message components
+/*
+ * Author: GPT-5 Codex
+ * Date: 2025-10-17 19:24 UTC
+ * PURPOSE: Render debate messages while wiring debate-specific log drawers and continue controls.
+ * SRP/DRY check: Pass - Component focuses on list composition and actions, delegating card rendering.
  */
 
 import { Play, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { MessageCard, type MessageCardData } from '@/components/MessageCard';
 import type { AIModel } from '@/types/ai-models';
-
-interface DebateMessage {
-  id: string;
-  modelId: string;
-  modelName: string;
-  content: string;
-  timestamp: number;
-  round: number;
-  reasoning?: string;
-  systemPrompt?: string;
-  responseTime: number;
-  tokenUsage?: {
-    input: number;
-    output: number;
-    reasoning?: number;
-  };
-  cost?: {
-    input: number;
-    output: number;
-    reasoning?: number;
-    total: number;
-  };
-  modelConfig?: {
-    capabilities: {
-      reasoning: boolean;
-      multimodal: boolean;
-      functionCalling: boolean;
-      streaming: boolean;
-    };
-    pricing: {
-      inputPerMillion: number;
-      outputPerMillion: number;
-      reasoningPerMillion?: number;
-    };
-  };
-}
+import type { DebateMessage } from '@/hooks/useDebateSession';
+import { DebateMessageCard } from '@/components/debate/DebateMessageCard';
 
 interface DebateMessageListProps {
   messages: DebateMessage[];
@@ -68,85 +31,65 @@ export function DebateMessageList({
   isStreaming,
   onContinueDebate,
 }: DebateMessageListProps) {
-  // Convert DebateMessage to MessageCardData format
-  const convertToMessageCardData = (message: DebateMessage): MessageCardData => {
-    const model = models.find(m => m.id === message.modelId);
-
-    return {
-      id: message.id,
-      modelName: message.modelName,
-      modelId: message.modelId,
-      content: message.content,
-      reasoning: message.reasoning,
-      systemPrompt: message.systemPrompt,
-      responseTime: message.responseTime,
-      round: message.round,
-      timestamp: message.timestamp,
-      type: 'debate',
-      tokenUsage: message.tokenUsage,
-      cost: message.cost,
-      modelConfig: {
-        provider: model?.provider,
-        capabilities: message.modelConfig?.capabilities || {
-          reasoning: !!message.reasoning,
-          multimodal: false,
-          functionCalling: false,
-          streaming: false
-        },
-        pricing: message.modelConfig?.pricing
-      }
-    };
-  };
-
   return (
     <div className="space-y-4">
-      {messages.map((message, index) => (
-        <div key={message.id} className={`${
-          message.modelId === model1Id ? 'ml-0 mr-8' : 'ml-8 mr-0'
-        }`}>
-          {/* Debate side indicator */}
-          <div className="flex items-center space-x-2 mb-2">
-            <div className={`w-3 h-3 rounded-full ${
-              message.modelId === model1Id ? 'bg-blue-500' : 'bg-green-500'
-            }`} />
-            <Badge variant="outline" className="text-xs">
-              {message.modelId === model1Id ? 'Pro' : 'Con'} - Round {message.round}
-            </Badge>
-          </div>
+      {messages.map((message, index) => {
+        const seatColor = message.modelId === model1Id
+          ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800'
+          : 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800';
+        const opponentMessagesForTurn = messages.filter(m => m.modelId !== message.modelId);
 
-          <MessageCard
-            message={convertToMessageCardData(message)}
-            variant="detailed"
-            showHeader={true}
-            showFooter={true}
-            className="shadow-sm"
-          />
-
-          {/* Continue Button - Only show on the last message */}
-          {index === messages.length - 1 && currentRound > 0 && (
-            <div className="mt-4">
-              <Button
-                onClick={onContinueDebate}
-                size="sm"
-                className="bg-green-600 hover:bg-green-700 w-full"
-                disabled={isStreaming}
-              >
-                {isStreaming ? (
-                  <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    Streaming response...
-                  </>
-                ) : (
-                  <>
-                    <Play className="w-4 h-4 mr-2" />
-                    Continue - {models.find(m => m.id === (currentRound % 2 === 1 ? model2Id : model1Id))?.name}'s turn
-                  </>
-                )}
-              </Button>
+        return (
+          <div
+            key={message.id}
+            id={message.id}
+            className={`${message.modelId === model1Id ? 'ml-0 mr-8' : 'ml-8 mr-0'}`}
+          >
+            {/* Debate side indicator */}
+            <div className="flex items-center space-x-2 mb-2">
+              <div
+                className={`w-3 h-3 rounded-full ${
+                  message.modelId === model1Id ? 'bg-blue-500' : 'bg-green-500'
+                }`}
+              />
+              <Badge variant="outline" className="text-xs">
+                {message.modelId === model1Id ? 'Pro' : 'Con'} - Round {message.round}
+              </Badge>
             </div>
-          )}
-        </div>
-      ))}
+
+            <DebateMessageCard
+              message={message}
+              models={models}
+              seatColor={seatColor}
+              opponentMessages={opponentMessagesForTurn}
+            />
+
+            {/* Continue Button - Only show on the last message */}
+            {index === messages.length - 1 && currentRound > 0 && (
+              <div className="mt-4">
+                <Button
+                  onClick={onContinueDebate}
+                  size="sm"
+                  className="bg-green-600 hover:bg-green-700 w-full"
+                  disabled={isStreaming}
+                >
+                  {isStreaming ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Streaming response...
+                    </>
+                  ) : (
+                    <>
+                      <Play className="w-4 h-4 mr-2" />
+                      Continue - {models.find(m => m.id === (currentRound % 2 === 1 ? model2Id : model1Id))?.name}'s turn
+                    </>
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/client/src/components/debate/ReasoningTimeline.tsx
+++ b/client/src/components/debate/ReasoningTimeline.tsx
@@ -1,0 +1,216 @@
+/*
+ * Author: GPT-5 Codex
+ * Date: 2025-10-17 19:05 UTC
+ * PURPOSE: Render synchronized reasoning and content chunk timelines with scrub controls and inflection highlights.
+ * SRP/DRY check: Pass - Component visualizes chunk telemetry without managing streaming state or persistence.
+ */
+
+import { useMemo, useState, useEffect } from 'react';
+import { Slider } from '@/components/ui/slider';
+import type { ReasoningStreamChunk, ContentStreamChunk } from '@/hooks/useAdvancedStreaming';
+import { computeInflectionThreshold } from '@/lib/chunkAnalytics';
+
+interface TimelinePoint {
+  timestamp: number;
+  position: number;
+  intensity: number;
+  delta: string;
+  cumulativeText: string;
+  isInflection: boolean;
+}
+
+interface ReasoningTimelineProps {
+  reasoningChunks: ReasoningStreamChunk[];
+  contentChunks: ContentStreamChunk[];
+  selectedTimestamp?: number;
+  onScrub?: (timestamp: number) => void;
+}
+
+const toRelativePosition = (timestamp: number, minTimestamp: number, range: number): number => {
+  if (range <= 0) {
+    return 0;
+  }
+  return ((timestamp - minTimestamp) / range) * 100;
+};
+
+export function ReasoningTimeline({
+  reasoningChunks,
+  contentChunks,
+  selectedTimestamp,
+  onScrub,
+}: ReasoningTimelineProps) {
+  const allTimestamps = useMemo(() => {
+    const combined = [...reasoningChunks, ...contentChunks];
+    if (!combined.length) {
+      return { min: Date.now(), max: Date.now() + 1 };
+    }
+    const timestamps = combined.map(chunk => chunk.timestamp);
+    return {
+      min: Math.min(...timestamps),
+      max: Math.max(...timestamps)
+    };
+  }, [reasoningChunks, contentChunks]);
+
+  const timeRange = Math.max(allTimestamps.max - allTimestamps.min, 1);
+
+  const reasoningThreshold = useMemo(
+    () => computeInflectionThreshold(reasoningChunks),
+    [reasoningChunks]
+  );
+  const contentThreshold = useMemo(
+    () => computeInflectionThreshold(contentChunks),
+    [contentChunks]
+  );
+
+  const reasoningPoints = useMemo<TimelinePoint[]>(() =>
+    reasoningChunks.map(chunk => ({
+      timestamp: chunk.timestamp,
+      position: toRelativePosition(chunk.timestamp, allTimestamps.min, timeRange),
+      intensity: chunk.intensity,
+      delta: chunk.delta,
+      cumulativeText: chunk.cumulativeText,
+      isInflection: chunk.intensity >= reasoningThreshold
+    })),
+    [reasoningChunks, reasoningThreshold, allTimestamps.min, timeRange]
+  );
+
+  const contentPoints = useMemo<TimelinePoint[]>(() =>
+    contentChunks.map(chunk => ({
+      timestamp: chunk.timestamp,
+      position: toRelativePosition(chunk.timestamp, allTimestamps.min, timeRange),
+      intensity: chunk.intensity,
+      delta: chunk.delta,
+      cumulativeText: chunk.cumulativeText,
+      isInflection: chunk.intensity >= contentThreshold
+    })),
+    [contentChunks, contentThreshold, allTimestamps.min, timeRange]
+  );
+
+  const [internalTimestamp, setInternalTimestamp] = useState(() => selectedTimestamp ?? allTimestamps.min);
+
+  useEffect(() => {
+    if (typeof selectedTimestamp === 'number') {
+      setInternalTimestamp(selectedTimestamp);
+    }
+  }, [selectedTimestamp]);
+
+  const scrubPercentage = toRelativePosition(internalTimestamp, allTimestamps.min, timeRange);
+
+  const handleScrub = (values: number[]) => {
+    const [percentage] = values;
+    const normalized = allTimestamps.min + (percentage / 100) * timeRange;
+    setInternalTimestamp(normalized);
+    onScrub?.(normalized);
+  };
+
+  const formatRelativeSeconds = (timestamp: number) => {
+    const elapsed = (timestamp - allTimestamps.min) / 1000;
+    return `${elapsed.toFixed(2)}s`;
+  };
+
+  const nearestReasoningChunk = useMemo(() => {
+    if (!reasoningChunks.length) {
+      return undefined;
+    }
+    return reasoningChunks.reduce((closest, chunk) => {
+      const closestDiff = Math.abs((closest?.timestamp ?? allTimestamps.min) - internalTimestamp);
+      const currentDiff = Math.abs(chunk.timestamp - internalTimestamp);
+      return currentDiff < closestDiff ? chunk : closest;
+    }, reasoningChunks[0]);
+  }, [reasoningChunks, internalTimestamp, allTimestamps.min]);
+
+  const nearestContentChunk = useMemo(() => {
+    if (!contentChunks.length) {
+      return undefined;
+    }
+    return contentChunks.reduce((closest, chunk) => {
+      const closestDiff = Math.abs((closest?.timestamp ?? allTimestamps.min) - internalTimestamp);
+      const currentDiff = Math.abs(chunk.timestamp - internalTimestamp);
+      return currentDiff < closestDiff ? chunk : closest;
+    }, contentChunks[0]);
+  }, [contentChunks, internalTimestamp, allTimestamps.min]);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
+          <span>Reasoning timeline</span>
+          <span>Inflections highlighted</span>
+        </div>
+        <div className="relative h-8 rounded-md bg-slate-100 dark:bg-slate-800/60">
+          {reasoningPoints.map(point => (
+            <div
+              key={`reason-${point.timestamp}-${point.position}`}
+              className="absolute bottom-1 flex -translate-x-1/2 flex-col items-center"
+              style={{ left: `${point.position}%` }}
+            >
+              <div
+                className={`rounded-full ${
+                  point.isInflection
+                    ? 'h-6 w-2 bg-amber-500 shadow-[0_0_6px_rgba(251,191,36,0.7)]'
+                    : 'h-4 w-1 bg-slate-400 dark:bg-slate-500'
+                }`}
+                title={`${formatRelativeSeconds(point.timestamp)} · ${point.intensity.toFixed(2)} intensity`}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
+          <span>Spoken text timeline</span>
+          <span>Delivery cadence</span>
+        </div>
+        <div className="relative h-8 rounded-md bg-slate-100 dark:bg-slate-800/60">
+          {contentPoints.map(point => (
+            <div
+              key={`content-${point.timestamp}-${point.position}`}
+              className="absolute top-1 flex -translate-x-1/2 flex-col items-center"
+              style={{ left: `${point.position}%` }}
+            >
+              <div
+                className={`rounded-full ${
+                  point.isInflection
+                    ? 'h-6 w-2 bg-sky-500 shadow-[0_0_6px_rgba(14,165,233,0.6)]'
+                    : 'h-4 w-1 bg-slate-400 dark:bg-slate-500'
+                }`}
+                title={`${formatRelativeSeconds(point.timestamp)} · ${point.intensity.toFixed(2)} intensity`}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <Slider value={[scrubPercentage]} min={0} max={100} step={0.5} onValueChange={handleScrub} />
+        <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-700 dark:bg-slate-800/40">
+          <div className="flex items-center justify-between">
+            <span className="font-semibold text-slate-700 dark:text-slate-200">Scrubber</span>
+            <span className="font-mono text-slate-600 dark:text-slate-300">
+              {formatRelativeSeconds(internalTimestamp)}
+            </span>
+          </div>
+          <div className="mt-2 grid gap-2 text-slate-600 dark:text-slate-300">
+            {nearestReasoningChunk && (
+              <div>
+                <span className="font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-300">Reasoning</span>
+                <p className="mt-1 whitespace-pre-wrap text-xs leading-relaxed text-slate-700 dark:text-slate-200">
+                  {nearestReasoningChunk.delta.trim() || '…'}
+                </p>
+              </div>
+            )}
+            {nearestContentChunk && (
+              <div>
+                <span className="font-semibold uppercase tracking-wide text-sky-600 dark:text-sky-300">Spoken</span>
+                <p className="mt-1 whitespace-pre-wrap text-xs leading-relaxed text-slate-700 dark:text-slate-200">
+                  {nearestContentChunk.delta.trim() || '…'}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/hooks/useDebateSession.ts
+++ b/client/src/hooks/useDebateSession.ts
@@ -1,13 +1,12 @@
-/**
- * Custom hook for managing debate session state
- *
- * Author: Cascade
- * Date: October 15, 2025
- * PURPOSE: Manages debate session state including messages, rounds, response tracking, and session management
- * SRP/DRY check: Pass - Single responsibility for debate session state management
+/*
+ * Author: GPT-5 Codex
+ * Date: 2025-10-17 18:56 UTC
+ * PURPOSE: Persist debate messages alongside structured reasoning/content chunk timelines for replay tooling.
+ * SRP/DRY check: Pass - Hook centralizes debate session state while delegating analytics to downstream components.
  */
 
 import { useState } from 'react';
+import type { ReasoningStreamChunk, ContentStreamChunk } from '@/hooks/useAdvancedStreaming';
 
 export interface DebateMessage {
   id: string;
@@ -19,6 +18,8 @@ export interface DebateMessage {
   reasoning?: string;
   systemPrompt?: string;
   responseTime: number;
+  reasoningChunks?: ReasoningStreamChunk[];
+  contentChunks?: ContentStreamChunk[];
   tokenUsage?: {
     input: number;
     output: number;
@@ -84,7 +85,12 @@ export function useDebateSession(): DebateSessionState {
 
   // Helper function to add a single message
   const addMessage = (message: DebateMessage) => {
-    setMessages(prev => [...prev, message]);
+    const clonedMessage: DebateMessage = {
+      ...message,
+      reasoningChunks: message.reasoningChunks?.map(chunk => ({ ...chunk })),
+      contentChunks: message.contentChunks?.map(chunk => ({ ...chunk }))
+    };
+    setMessages(prev => [...prev, clonedMessage]);
   };
 
   // Reset function for session state

--- a/client/src/hooks/useDebateStreaming.ts
+++ b/client/src/hooks/useDebateStreaming.ts
@@ -1,18 +1,23 @@
-/**
- * Custom hook for managing debate streaming state
- *
- * Author: Cascade
- * Date: October 15, 2025
- * PURPOSE: Manages streaming-related state and integrates with useAdvancedStreaming hook
- * SRP/DRY check: Pass - Single responsibility for debate streaming state management
+/*
+ * Author: GPT-5 Codex
+ * Date: 2025-10-17 18:52 UTC
+ * PURPOSE: Wrap debate streaming hook to expose structured chunk arrays alongside legacy fields for replay UIs.
+ * SRP/DRY check: Pass - Delegates streaming mechanics to useAdvancedStreaming while reshaping consumer-facing state.
  */
 
-import { useAdvancedStreaming, type StreamingOptions } from '@/hooks/useAdvancedStreaming';
+import {
+  useAdvancedStreaming,
+  type StreamingOptions,
+  type ReasoningStreamChunk,
+  type ContentStreamChunk
+} from '@/hooks/useAdvancedStreaming';
 
 export interface DebateStreamingState {
   // Streaming state from useAdvancedStreaming
   reasoning: string;
   content: string;
+  reasoningChunks: ReasoningStreamChunk[];
+  contentChunks: ContentStreamChunk[];
   isStreaming: boolean;
   error: string | null;
   responseId: string | null;
@@ -35,6 +40,8 @@ export function useDebateStreaming(): DebateStreamingState {
   const {
     reasoning,
     content,
+    reasoningChunks,
+    contentChunks,
     isStreaming,
     error,
     responseId,
@@ -58,6 +65,8 @@ export function useDebateStreaming(): DebateStreamingState {
     // Streaming state
     reasoning,
     content,
+    reasoningChunks,
+    contentChunks,
     isStreaming,
     error,
     responseId,

--- a/client/src/lib/chunkAnalytics.ts
+++ b/client/src/lib/chunkAnalytics.ts
@@ -1,0 +1,46 @@
+/*
+ * Author: GPT-5 Codex
+ * Date: 2025-10-17 19:10 UTC
+ * PURPOSE: Provide reusable helpers for chunk intensity thresholds and proportional weighting analytics.
+ * SRP/DRY check: Pass - Module only handles numeric analytics for streaming chunks.
+ */
+
+import type { StreamChunkBase } from '@/hooks/useAdvancedStreaming';
+
+export interface WeightedChunk<T extends StreamChunkBase> {
+  chunk: T;
+  weight: number;
+  cumulativeWeight: number;
+}
+
+export const computeInflectionThreshold = <T extends StreamChunkBase>(chunks: T[]): number => {
+  if (!chunks.length) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const intensities = chunks.map(chunk => chunk.intensity);
+  const average = intensities.reduce((sum, value) => sum + value, 0) / intensities.length;
+  const variance = intensities.reduce((sum, value) => sum + Math.pow(value - average, 2), 0) / intensities.length;
+  const stdDeviation = Math.sqrt(variance);
+  return average + stdDeviation * 1.25;
+};
+
+export const weightChunks = <T extends StreamChunkBase>(chunks: T[]): WeightedChunk<T>[] => {
+  if (!chunks.length) {
+    return [];
+  }
+  const totalChars = chunks.reduce((sum, chunk) => sum + Math.max(chunk.charCount, 1), 0);
+  if (totalChars <= 0) {
+    return chunks.map(chunk => ({ chunk, weight: 0, cumulativeWeight: 0 }));
+  }
+
+  let cumulative = 0;
+  return chunks.map(chunk => {
+    const weight = Math.max(chunk.charCount, 1) / totalChars;
+    cumulative += weight;
+    return {
+      chunk,
+      weight,
+      cumulativeWeight: cumulative
+    };
+  });
+};

--- a/docs/2025-10-17-plan-debate-timelines.md
+++ b/docs/2025-10-17-plan-debate-timelines.md
@@ -1,0 +1,22 @@
+* Author: GPT-5 Codex
+* Date: 2025-10-17 18:45 UTC
+* PURPOSE: Outline approach for preserving structured streaming chunks, persisting them across debate turns, and surfacing them in new timeline/log UI elements.
+* SRP/DRY check: Pass - Planning document centralizes current task scope without duplicating existing plans.
+
+## Objectives
+- Capture timestamped reasoning and content chunks during debate streaming for later analysis.
+- Persist structured chunk arrays per debate turn so post-stream review features can replay them.
+- Introduce UI for exploring reasoning timelines and detailed per-turn logs inside debate mode.
+
+## Tasks
+1. Extend `useAdvancedStreaming` to accumulate chunk arrays with timestamps, expose reusable chunk types, and continue deriving concatenated strings for backward compatibility.
+2. Update `useDebateStreaming` to surface new chunk arrays and reset helpers, ensuring consumers can replay streams after completion.
+3. Enhance `useDebateSession` to accept structured chunk payloads via `addMessage` and retain them per message for retrospective playback.
+4. Build `ReasoningTimeline` component rendering synchronized reasoning/content timelines with scrubber controls and inflection point highlighting derived from chunk intensity metrics.
+5. Wrap `MessageCard` for debate mode (or enhance directly) to add a "View Log" drawer showing the timeline, reasoning playback, and token/cost delta insights referencing opponent statements.
+6. Integrate new components into debate UI, wiring stored chunk data into the drawer and ensuring exported data remains consistent.
+
+## Notes
+- Compute intensity heuristics using delta length over elapsed time to detect spikes.
+- Maintain SRP by keeping analytics helpers in a dedicated utility function where necessary.
+- Reuse existing UI primitives (Drawer, Slider, Timeline styles) to stay consistent with design system.


### PR DESCRIPTION
## Summary
- capture timestamped reasoning/content chunks in the streaming hooks and expose them through debate state
- persist chunk timelines per debate message and add a timeline/log drawer for debate cards with analytics helpers
- integrate the new ReasoningTimeline UI and planning notes for the debate review experience

## Testing
- npm run check *(fails: existing TypeScript errors in luigi/auth/provider modules)*

------
https://chatgpt.com/codex/tasks/task_e_68f28c783a10832698742f224ee482f5