### PR TITLE
Restore jury review gating after annotation edits

### DIFF
--- a/client/src/hooks/useDebateSession.ts
+++ b/client/src/hooks/useDebateSession.ts
@@ -457,6 +457,7 @@ export function useDebateSession(): DebateSessionState {
         [modelId]: {
           ...current,
           tags: hasTag ? current.tags.filter(t => t !== tag) : [...current.tags, tag],
+          needsReview: true,
         },
       };
     });
@@ -468,11 +469,15 @@ export function useDebateSession(): DebateSessionState {
       if (!current) {
         return prev;
       }
+      if (current.notes === notes) {
+        return prev;
+      }
       return {
         ...prev,
         [modelId]: {
           ...current,
           notes,
+          needsReview: true,
         },
       };
     });

--- a/docs/2025-10-17-plan-jury-annotation-review.md
+++ b/docs/2025-10-17-plan-jury-annotation-review.md
@@ -1,0 +1,21 @@
+* Author: gpt-5-codex
+* Date: 2025-10-17 19:40 UTC
+* PURPOSE: Outline tasks to restore jury annotation review gating after post-review edits.
+* SRP/DRY check: Pass - Planning document centralizes steps without duplicating existing instructions.
+
+# Plan for Jury Annotation Review Gating Fix
+
+## Goal
+Ensure jury annotation mutations (tags and notes) reinstate the review requirement so the gating logic blocks progression after any post-review edits.
+
+## Tasks
+1. Audit `useDebateSession` mutation handlers to confirm where `needsReview` should be updated when annotations change.
+2. Update `toggleJuryTag` and `setJuryNotes` to set `needsReview` back to `true` whenever changes occur.
+3. Verify no other handlers need adjustments and run targeted reasoning to ensure gating logic respects updates.
+4. Prepare tests or manual validation notes if automated coverage is absent.
+5. Document changes via commit and PR message following repository guidelines.
+
+## Considerations
+- Maintain SRP by keeping review flag logic encapsulated within annotation mutations.
+- Avoid unintended resets when annotations are initialized or cleared.
+- Confirm state updates remain immutable and consistent with existing hook patterns.


### PR DESCRIPTION
## Summary
- ensure jury tag and note mutations mark annotations for review after edits
- add planning document covering gating fix approach

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f29b8d3e8c8326adf4a366479daf58