### PR TITLE
Fix debate page phase import regression

### DIFF
--- a/client/src/pages/debate.tsx
+++ b/client/src/pages/debate.tsx
@@ -24,6 +24,7 @@ import type { AIModel } from '@/types/ai-models';
 import { useDebateSetup } from "@/hooks/useDebateSetup";
 import {
   useDebateSession,
+  ROBERTS_RULES_PHASES,
   type DebateSessionSummary,
   type DebateSessionHydration,
 } from "@/hooks/useDebateSession";

--- a/docs/2025-10-17-plan-debate-streaming.md
+++ b/docs/2025-10-17-plan-debate-streaming.md
@@ -21,3 +21,8 @@ Align the client debate streaming hook with the consolidated `/api/debate/stream
 ## Verification Notes
 - Manual testing: initiate a debate turn via `/debate` UI, confirming reasoning and text append progressively and no "Failed to initialize stream" toast appears.
 - Regression awareness: monitor estimated cost/progress updates and cancellation behavior to ensure parity with prior implementation.
+
+## 2025-10-17 22:31 UTC Update
+- [x] Investigated `ROBERTS_RULES_PHASES` runtime reference errors triggered in `client/src/pages/debate.tsx`.
+- [x] Confirmed constant export already exists in `useDebateSession` and should be imported where used.
+- [ ] Validate debate UI after adjusting imports to ensure structured phase metadata renders and streaming resumes.


### PR DESCRIPTION
## Summary
- import the ROBERTS_RULES_PHASES constant into the debate page so phase metadata renders without runtime errors
- log the investigation of the missing constant in the existing debate streaming plan document

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1a4dd211883269b17457b4d1c0e9a