### PR TITLE
Fortify debate streaming handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,25 @@
 # Changelog
 <!--
  * Author: GPT-5 Codex
- * Date: 2025-10-17 18:14 UTC
+ * Date: 2025-10-18 00:50 UTC
  * PURPOSE: Maintain a human-readable history of notable changes for releases and audits.
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
+
+## [Version 0.4.10] - 2025-10-18
+
+### Added
+- **Debate Handshake Regression Test:** Added `tests/server/debate-handshake.test.ts` to boot the debate router with mocked
+  providers, assert the POST→GET handshake, parse SSE chunks, and verify debate turn persistence through the shared storage
+  layer.
+
+### Changed
+- **Legacy Debate Endpoint Hardening:** Updated `server/routes/debate.routes.ts` so direct `POST /api/debate/stream` calls return
+  `410 Gone` with upgrade guidance, ensuring no caller silently reverts to the retired single-request flow.
+
+### Documentation
+- **Streaming Validation Plan:** Captured regression goals and verification steps in
+  `docs/2025-10-18-plan-debate-streaming-validation.md` for future release audits.
 
 ## [Version 0.4.9] - 2025-10-17
 
@@ -22,7 +37,7 @@
 - **Changelog Alignment:** Bumped the documented release to capture the streaming retrofit and ensure downstream audit trails remain accurate.
 
 ### Removed
-- **Legacy Debate Streaming Contract:** Deleted `client/src/hooks/useDebateStream.ts` and the fallback `POST /api/debate/stream` route to eliminate ambiguity now that all clients use the init + SSE handshake via `useDebateStreaming`.
+- **Legacy Debate Streaming Contract:** Deleted `client/src/hooks/useDebateStream.ts` and the fallback `POST /api/debate/stream` route so the two-phase init + SSE handshake is the only supported debate streaming path.
 
 ## [Version 0.4.8] - 2025-10-17
 
@@ -73,7 +88,7 @@
 ## [Version 0.4.4] - 2025-10-17
 
 ### Fixed
-- **Debate Streaming Contract Alignment:** Added `/api/debate/stream/init` plus SSE GET handler, consolidated streaming logic, and retained the legacy POST endpoint so the frontend hook and scripting workflows both reach OpenAI.
+- **Debate Streaming Contract Alignment:** Added `/api/debate/stream/init` plus SSE GET handler, consolidated streaming logic, and temporarily retained the legacy POST endpoint for compatibility (subsequently removed in v0.4.9).
 
 ## [Version 0.4.3] - 2025-10-16
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ The `IStorage` interface in `server/storage.ts` provides:
 - Automated debate progression with manual turn-by-turn controls
 - **Advanced Streaming Features**:
   - Server-Sent Events (SSE) for real-time reasoning and content display
-  - `/api/debate/stream` endpoint with init + stream contract
+  - Two-phase streaming handshake via `POST /api/debate/stream/init` followed by
+    `GET /api/debate/stream/:taskId/:modelKey/:sessionId`
   - Conversation chaining using OpenAI Responses API `response.id` tracking
   - Database session persistence with turn history
   - Model-specific configuration (reasoning effort, temperature, max tokens)
@@ -299,8 +300,8 @@ GET  /api/comparisons/:id  # Retrieve specific comparison
 # Debate Mode (with streaming)
 POST /api/debate/session      # Create new debate session
 GET  /api/debate/sessions     # List existing debate sessions
-POST /api/debate/stream       # Initialize debate streaming (SSE)
-GET  /api/debate/stream       # Stream debate responses (SSE)
+POST /api/debate/stream/init                     # Validate payload and create streaming session
+GET  /api/debate/stream/:taskId/:modelKey/:sessionId  # Stream debate responses via SSE
 
 # Model Responses
 POST /api/models/respond      # Get single model response

--- a/docs/2025-10-17-plan-debate-endpoint.md
+++ b/docs/2025-10-17-plan-debate-endpoint.md
@@ -1,0 +1,23 @@
+<!--
+ * Author: GPT-5 Codex
+ * Date: 2025-10-17 23:26 UTC
+ * PURPOSE: Document the action plan to verify the debate streaming endpoint uses the
+ *          new init+SSE workflow, preserve recent backend work, and align docs.
+ * SRP/DRY check: Pass - Plan file tracks tasks for this fix only; no redundant plan exists.
+-->
+# Debate Endpoint Verification & Documentation Plan
+
+## Goals
+- Confirm the `/api/debate` routes are serving the new init + SSE handshake.
+- Ensure no code paths fall back to the removed legacy POST `/api/debate/stream` endpoint.
+- Align repository documentation (README, changelog, reference docs) with the current implementation so contributors do not default to legacy flows.
+
+## Tasks
+1. Inspect `server/routes/debate.routes.ts` and related streaming helpers to verify only the handshake endpoints exist and operate as expected.
+2. Search the codebase for any lingering calls to the legacy `POST /api/debate/stream` endpoint; refactor or remove stale references if found.
+3. Update README and other docs (e.g., `CHANGELOG.md`, route docs) to describe the init + SSE flow explicitly and remove language suggesting the legacy route remains.
+4. Run targeted lint or type checks if necessary to ensure documentation changes do not introduce build issues (docs-only so no build expected).
+
+## Validation
+- `git status` shows only intentional doc/code updates.
+- Documentation clearly states that the legacy single-call endpoint is removed and points to the new flow.

--- a/docs/2025-10-18-plan-debate-streaming-validation.md
+++ b/docs/2025-10-18-plan-debate-streaming-validation.md
@@ -1,0 +1,34 @@
+* Author: GPT-5 Codex
+* Date: 2025-10-18 00:45 UTC
+* PURPOSE: Document validation plan to preserve the modern debate streaming handshake by adding regression
+*          coverage, endpoint hardening, and automated verification that the SSE pipeline persists turn data.
+* SRP/DRY check: Pass - Captures plan only; verification steps reuse implemented routes/tests elsewhere.
+
+# 2025-10-18 Debate Streaming Validation Plan
+
+## Goals
+- Reinforce the `/api/debate/stream/init` → `/api/debate/stream/:taskId/:modelKey/:sessionId` handshake.
+- Prevent silent fallbacks to the legacy single POST endpoint by hard failing calls to `/api/debate/stream`.
+- Add automated coverage that mocks provider streaming and asserts persisted session data integrity.
+
+## Tasks
+1. **Endpoint Hardening**
+   - Update `server/routes/debate.routes.ts` to emit an explicit `410 Gone` JSON response from the retired
+     `POST /api/debate/stream` route, guiding callers to the handshake flow.
+   - Maintain streaming init + SSE handlers with shared helpers and TTL registry cleanup.
+
+2. **Automated Regression Coverage**
+   - Write Vitest integration targeting the debate router to spin up an Express app with mocked provider
+     streaming and in-memory storage fallback.
+   - Verify init route returns session metadata, SSE stream emits init/status/chunk/complete events, and
+     session persistence captures turn history and response identifiers.
+   - Assert subsequent GET reuse fails (session consumed) and the legacy endpoint returns `410`.
+
+3. **Documentation & Change Log**
+   - Summarize validation scope in this plan for future traceability.
+   - Reference automated tests in PR summary to demonstrate coverage.
+
+## Acceptance Criteria
+- Automated test passes locally without external API calls.
+- Legacy endpoint responds with 410 and migration hint.
+- SSE test confirms persisted debate session with reasoning/content captured in storage turn history.

--- a/server/routes/debate.routes.ts
+++ b/server/routes/debate.routes.ts
@@ -1,12 +1,12 @@
 /*
  * Author: GPT-5 Codex
- * Date: 2025-10-17 18:14 UTC
+ * Date: 2025-10-18 00:55 UTC
  * PURPOSE: Align debate streaming routes with the two-stage client contract, providing an init endpoint,
  *          SSE dispatcher, shared streaming logic, and heartbeat keepalives so modern React clients can
  *          consume Responses API streams without premature proxy disconnects while persisting debate turns.
  * SRP/DRY check: Pass - Route module handles debate HTTP concerns only; shared helpers prevent duplication
  *                across init and SSE entry points.
-*/
+ */
 import { Router } from "express";
 import { getProviderForModel } from "../providers/index.js";
 import { storage } from "../storage.js";
@@ -518,6 +518,14 @@ router.get("/stream/:taskId/:modelKey/:sessionId", async (req, res) => {
   });
 
   await streamDebateTurn(harness, sessionEntry.payload);
+});
+
+router.post("/stream", (_req, res) => {
+  res.status(410).json({
+    error: "Legacy debate stream endpoint removed",
+    message:
+      "Use POST /api/debate/stream/init followed by GET /api/debate/stream/:taskId/:modelKey/:sessionId"
+  });
 });
 
 export { router as debateRoutes };

--- a/tests/server/debate-handshake.test.ts
+++ b/tests/server/debate-handshake.test.ts
@@ -1,0 +1,208 @@
+/*
+ * Author: GPT-5 Codex
+ * Date: 2025-10-18 01:05 UTC
+ * PURPOSE: Verify the debate streaming handshake persists SSE semantics, rejects legacy routes, and
+ *          stores debate turns using the in-memory storage fallback with a mocked provider stream.
+ * SRP/DRY check: Pass - Focused on router-level integration; reuses production router and storage modules
+ *                while isolating external providers via targeted mocks.
+ */
+
+import { beforeAll, afterAll, describe, expect, test, vi } from 'vitest';
+import express from 'express';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+
+const providersModulePath = vi.hoisted(() => new URL('../../server/providers/index.ts', import.meta.url).href);
+
+const providerStreamMock = vi.fn(async ({
+  onStatus,
+  onReasoningChunk,
+  onContentChunk,
+  onComplete
+}: any) => {
+  onStatus?.('provider_ready', { provider: 'MockProvider' });
+  await new Promise(resolve => setTimeout(resolve, 5));
+  onReasoningChunk('Mock reasoning.');
+  await new Promise(resolve => setTimeout(resolve, 5));
+  onContentChunk('Mock content.');
+  await new Promise(resolve => setTimeout(resolve, 5));
+  onComplete(
+    'resp_mock',
+    {
+      input_tokens: 12,
+      output_tokens: 24,
+      output_tokens_details: { reasoning_tokens: 6 }
+    },
+    { total: 0.04, input: 0.02, output: 0.02 },
+    {
+      content: 'Mock content.',
+      reasoning: 'Mock reasoning.',
+      structuredOutput: { verdict: 'mock' }
+    }
+  );
+});
+
+vi.mock(providersModulePath, () => ({
+  __esModule: true,
+  getProviderForModel: vi.fn(() => ({
+    name: 'MockProvider',
+    callModelStreaming: providerStreamMock
+  }))
+}));
+
+const debateRoutesModulePath = new URL('../../server/routes/debate.routes.ts', import.meta.url).href;
+const storageModulePath = new URL('../../server/storage.ts', import.meta.url).href;
+
+let server: import('node:http').Server | null = null;
+let baseUrl = '';
+let debateRoutes: typeof import('../../server/routes/debate.routes') extends { debateRoutes: infer T } ? T : never;
+let storage: typeof import('../../server/storage');
+
+beforeAll(async () => {
+  const [routesModule, storageModule] = await Promise.all([
+    import(debateRoutesModulePath),
+    import(storageModulePath)
+  ]);
+  debateRoutes = routesModule.debateRoutes;
+  storage = storageModule;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/debate', debateRoutes);
+
+  server = app.listen(0);
+  await once(server, 'listening');
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server!.close(error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+});
+
+describe('Debate streaming handshake', () => {
+  test('streams via SSE and persists turn data', async () => {
+    const createSessionResponse = await fetch(`${baseUrl}/api/debate/session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic: 'AI ethics in autonomous vehicles',
+        model1Id: 'gpt-4o-mini-2024-07-18',
+        model2Id: 'gpt-4o-mini-2024-07-18',
+        adversarialLevel: 3
+      })
+    });
+    expect(createSessionResponse.status).toBe(200);
+    const sessionInfo = await createSessionResponse.json();
+    expect(sessionInfo).toHaveProperty('id');
+
+    const initResponse = await fetch(`${baseUrl}/api/debate/stream/init`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        modelId: 'gpt-4o-mini-2024-07-18',
+        topic: 'AI ethics in autonomous vehicles',
+        role: 'AFFIRMATIVE',
+        intensity: 3,
+        opponentMessage: null,
+        previousResponseId: null,
+        turnNumber: 1,
+        reasoningEffort: 'high',
+        reasoningSummary: 'detailed',
+        reasoningVerbosity: 'high',
+        temperature: 0.2,
+        maxTokens: 256,
+        sessionId: sessionInfo.id,
+        model1Id: sessionInfo.model1Id,
+        model2Id: sessionInfo.model2Id
+      })
+    });
+
+    expect(initResponse.status).toBe(200);
+    const initPayload = await initResponse.json();
+    expect(initPayload).toMatchObject({
+      sessionId: expect.any(String),
+      taskId: expect.any(String),
+      modelKey: expect.any(String)
+    });
+
+    const { sessionId, taskId, modelKey } = initPayload;
+    const streamResponse = await fetch(
+      `${baseUrl}/api/debate/stream/${encodeURIComponent(taskId)}/${encodeURIComponent(modelKey)}/${encodeURIComponent(sessionId)}`,
+      { method: 'GET' }
+    );
+    expect(streamResponse.status).toBe(200);
+    expect(streamResponse.headers.get('content-type')).toContain('text/event-stream');
+
+    const reader = streamResponse.body?.getReader();
+    expect(reader).toBeTruthy();
+
+    const decoder = new TextDecoder();
+    const events: Array<{ event: string; data: any }> = [];
+    let buffer = '';
+    let completeReceived = false;
+
+    while (!completeReceived && reader) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      let boundary = buffer.indexOf('\n\n');
+      while (boundary !== -1) {
+        const rawEvent = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        if (rawEvent.trim().length > 0) {
+          const lines = rawEvent.split('\n');
+          const eventLine = lines.find(line => line.startsWith('event:')) ?? '';
+          const dataLine = lines.find(line => line.startsWith('data:')) ?? '';
+          const eventName = eventLine.replace('event:', '').trim();
+          const payloadText = dataLine.replace('data:', '').trim();
+          const payload = payloadText ? JSON.parse(payloadText) : null;
+          events.push({ event: eventName, data: payload });
+          if (eventName === 'stream.complete') {
+            completeReceived = true;
+          }
+        }
+        boundary = buffer.indexOf('\n\n');
+      }
+    }
+
+    expect(events.some(evt => evt.event === 'stream.init')).toBe(true);
+    expect(events.some(evt => evt.event === 'stream.chunk')).toBe(true);
+    expect(events.some(evt => evt.event === 'stream.complete')).toBe(true);
+    const statusEvent = events.find(evt => evt.event === 'stream.status');
+    expect(statusEvent?.data?.phase).toBeDefined();
+
+    expect(providerStreamMock).toHaveBeenCalledTimes(1);
+
+    const persisted = await storage.storage.getDebateSession(sessionInfo.id);
+    expect(persisted).toBeTruthy();
+    expect(Array.isArray(persisted.turnHistory)).toBe(true);
+    expect(persisted.turnHistory).toHaveLength(1);
+    expect(persisted.turnHistory[0].content).toContain('Mock content');
+
+    const reuseResponse = await fetch(
+      `${baseUrl}/api/debate/stream/${encodeURIComponent(taskId)}/${encodeURIComponent(modelKey)}/${encodeURIComponent(sessionId)}`
+    );
+    expect(reuseResponse.status).toBe(404);
+  });
+
+  test('legacy POST /api/debate/stream returns 410 with guidance', async () => {
+    const response = await fetch(`${baseUrl}/api/debate/stream`, { method: 'POST' });
+    expect(response.status).toBe(410);
+    const payload = await response.json();
+    expect(payload.error).toContain('Legacy debate stream endpoint removed');
+    expect(payload.message).toContain('/api/debate/stream/init');
+  });
+});


### PR DESCRIPTION
## Summary
- harden the debate router so legacy `POST /api/debate/stream` calls return 410 with guidance toward the init+SSE handshake and capture the validation plan in docs
- add a Vitest integration that boots the debate router with a mocked streaming provider to assert the POST→GET handshake, parse SSE chunks, and verify debate session persistence
- record the regression coverage in the changelog for version 0.4.10

## Testing
- `npx vitest run tests/server/debate-handshake.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68f2d091e2088326b649dc344d3febd9