### PR TITLE
Default debate topic selection

### DIFF
--- a/client/src/hooks/useDebateSetup.ts
+++ b/client/src/hooks/useDebateSetup.ts
@@ -1,10 +1,8 @@
-/**
- * Custom hook for managing debate setup state
- *
- * Author: Cascade
- * Date: October 15, 2025
- * PURPOSE: Manages debate setup state including topic selection, model configuration, and UI state
- * SRP/DRY check: Pass - Single responsibility for debate setup state management
+/*
+ * Author: gpt-5-codex
+ * Date: 2025-02-14 00:10 UTC
+ * PURPOSE: Manage debate setup state including dynamic topic defaults, model configuration, and setup visibility controls.
+ * SRP/DRY check: Pass - Hook encapsulates setup state management without duplicating debate session logic.
  */
 
 import { useState } from 'react';
@@ -55,14 +53,13 @@ const initialModelConfig: ModelConfiguration = {
   enableStructuredOutput: false
 };
 
-const DEFAULT_TOPIC_ID = 'knights-of-the-sun';
 const DEFAULT_MODEL_1_ID = 'gpt-5-mini-2025-08-07';
 const DEFAULT_MODEL_2_ID = 'gpt-5-nano-2025-08-07';
 const DEFAULT_INTENSITY = 3;
 
 export function useDebateSetup(): DebateSetupState {
   // Topic state
-  const [selectedTopic, setSelectedTopic] = useState(DEFAULT_TOPIC_ID);
+  const [selectedTopic, setSelectedTopic] = useState('');
   const [customTopic, setCustomTopic] = useState('');
   const [useCustomTopic, setUseCustomTopic] = useState(false);
 
@@ -83,7 +80,7 @@ export function useDebateSetup(): DebateSetupState {
 
   // Reset function for setup state
   const resetSetup = () => {
-    setSelectedTopic(DEFAULT_TOPIC_ID);
+    setSelectedTopic('');
     setCustomTopic('');
     setUseCustomTopic(false);
     setAdversarialLevel(DEFAULT_INTENSITY);

--- a/client/src/pages/debate.tsx
+++ b/client/src/pages/debate.tsx
@@ -1,9 +1,8 @@
 /*
- * Author: GPT-5 Codex
- * Date: 2025-10-17 22:58 UTC
- * PURPOSE: Debate mode orchestrator that hydrates persisted turn history, reconciles streaming updates, and coordinates the
- *          modern streaming handshake while keeping exports, history, and jury controls aligned.
- * SRP/DRY check: Pass - Component composes hooks/services to manage debate state without duplicating underlying logic.
+ * Author: gpt-5-codex
+ * Date: 2025-02-14 00:12 UTC
+ * PURPOSE: Orchestrate debate mode, hydrate persisted history, manage streaming, and ensure setup defaults select a valid topic.
+ * SRP/DRY check: Pass - Component composes specialized hooks/services without overlapping their responsibilities.
  */
 
 import { useRef, useEffect, useMemo } from "react";
@@ -52,6 +51,10 @@ export default function Debate() {
 
   const { debateData, loading: debateLoading, error: debateError, generateDebatePrompts } = useDebatePrompts();
   const { exportMarkdown, copyToClipboard } = useDebateExport();
+
+  const setupSelectedTopic = debateSetup.selectedTopic;
+  const setupUseCustomTopic = debateSetup.useCustomTopic;
+  const setSetupSelectedTopic = debateSetup.setSelectedTopic;
 
   const { data: models = [] } = useQuery({
     queryKey: ['/api/models'],
@@ -167,6 +170,19 @@ export default function Debate() {
   useEffect(() => {
     loadDebateSessionsMutation.mutate();
   }, []);
+
+  useEffect(() => {
+    if (!debateData?.topics.length) {
+      return;
+    }
+    if (setupUseCustomTopic) {
+      return;
+    }
+    const hasValidSelection = debateData.topics.some(topic => topic.id === setupSelectedTopic);
+    if (!hasValidSelection) {
+      setSetupSelectedTopic(debateData.topics[0].id);
+    }
+  }, [debateData, setupSelectedTopic, setupUseCustomTopic, setSetupSelectedTopic]);
 
 
 

--- a/docs/2025-02-14-plan-debate-default-topic.md
+++ b/docs/2025-02-14-plan-debate-default-topic.md
@@ -1,0 +1,19 @@
+*
+* Author: gpt-5-codex
+* Date: 2025-02-14 00:00 UTC
+* PURPOSE: Document implementation plan for preselecting a default debate topic in the debate UI.
+* SRP/DRY check: Pass - Documentation only and scoped to a single planning responsibility.
+
+# Goal
+Ensure the debate page loads with a valid debate topic selected by default so the UI is ready to launch without manual preset selection.
+
+# Tasks
+- Inspect current debate setup state management to understand how topics are selected and reset.
+- Determine how debate topics are parsed and identify a reliable default topic identifier.
+- Update debate setup state to allow dynamic default topic assignment rather than relying on a hard-coded identifier.
+- Add an effect on the debate page that selects the first available topic once prompt data loads and no valid topic is chosen.
+- Verify the DebateTopicSelector reflects the default topic and that resetting the setup re-applies the default selection.
+
+# Validation
+- Load the debate page locally and confirm a topic appears selected immediately after prompts load.
+- Reset the debate setup and confirm the topic selection remains valid without manual input.


### PR DESCRIPTION
## Summary
- remove the hard-coded default topic id from the debate setup hook so the state can adopt real prompt data
- ensure the debate page selects the first available preset topic whenever prompts load without a valid selection
- add a planning document outlining the approach for default topic selection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3bc81d6a88326a559ae717103d5be