### PR TITLE
Colorize plan assessment defaults

### DIFF
--- a/client/src/components/plan-assessment/PlanAssessmentHero.tsx
+++ b/client/src/components/plan-assessment/PlanAssessmentHero.tsx
@@ -1,0 +1,305 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-18 20:10 UTC
+ * PURPOSE: Hero form for the plan assessment mode, mirroring the modern compare
+ *          layout while collecting plan inputs and managing inline model
+ *          selection. Updated to launch with vibrant gradients, colorful pills,
+ *          and accentuated buttons while preserving shared comparison logic.
+ * SRP/DRY check: Pass - Single responsibility (plan assessment hero section),
+ *                reuses shared comparison components without duplicating API logic.
+ */
+
+import { useState, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { FloatingModelPicker } from "@/components/comparison/FloatingModelPicker";
+import { ModelPill } from "@/components/comparison/ModelPill";
+import {
+  ClipboardList,
+  Brain,
+  Eye,
+  Zap,
+  Loader2,
+  Sparkles,
+} from "lucide-react";
+import type { AIModel, ModelResponse } from "@/types/ai-models";
+
+interface PlanAssessmentHeroProps {
+  finalPrompt: string;
+  hobbyDev: "hobby" | "enterprise";
+  onHobbyDevChange: (value: "hobby" | "enterprise") => void;
+  constraints: string;
+  onConstraintsChange: (value: string) => void;
+  planMarkdown: string;
+  onPlanMarkdownChange: (value: string) => void;
+  contextSummary: string;
+  onContextSummaryChange: (value: string) => void;
+  models: AIModel[];
+  modelsLoading: boolean;
+  selectedModels: string[];
+  loadingModels: Set<string>;
+  responses: Record<string, ModelResponse>;
+  onToggleModel: (modelId: string) => void;
+  onSelectAllModels: (modelIds: string[]) => void;
+  onClearAllModels: () => void;
+  onSubmit: () => void;
+  canSubmit: boolean;
+  isSubmitting: boolean;
+  disableSubmitReason?: string;
+}
+
+export function PlanAssessmentHero({
+  finalPrompt,
+  hobbyDev,
+  onHobbyDevChange,
+  constraints,
+  onConstraintsChange,
+  planMarkdown,
+  onPlanMarkdownChange,
+  contextSummary,
+  onContextSummaryChange,
+  models,
+  modelsLoading,
+  selectedModels,
+  loadingModels,
+  responses,
+  onToggleModel,
+  onSelectAllModels,
+  onClearAllModels,
+  onSubmit,
+  canSubmit,
+  isSubmitting,
+  disableSubmitReason,
+}: PlanAssessmentHeroProps) {
+  const [showPromptPreview, setShowPromptPreview] = useState(false);
+
+  const planWordCount = useMemo(() => {
+    const words = planMarkdown.trim().split(/\s+/).filter(Boolean);
+    return planMarkdown.trim().length === 0 ? 0 : words.length;
+  }, [planMarkdown]);
+
+  const promptWordCount = useMemo(() => {
+    const words = finalPrompt.trim().split(/\s+/).filter(Boolean);
+    return finalPrompt.trim().length === 0 ? 0 : words.length;
+  }, [finalPrompt]);
+
+  const selectedModelObjects = useMemo(
+    () => models.filter((model) => selectedModels.includes(model.id)),
+    [models, selectedModels],
+  );
+
+  const modelPickerTrigger = (
+    <Button
+      variant="default"
+      size="sm"
+      className="gap-1.5 h-8 bg-gradient-to-r from-primary via-fuchsia-500 to-orange-400 text-primary-foreground shadow-md hover:shadow-lg transition-all"
+      disabled={modelsLoading}
+    >
+      <Brain className="w-3 h-3 drop-shadow-sm" />
+      Manage Models
+      {selectedModels.length > 0 && (
+        <Badge
+          variant="secondary"
+          className="ml-1 h-4 px-1.5 text-[0.65rem] uppercase tracking-wide bg-background/80 text-primary border-none"
+        >
+          {selectedModels.length}
+        </Badge>
+      )}
+    </Button>
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card className="relative overflow-hidden border-2 border-primary/20 shadow-xl">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/10 via-background to-background" />
+        <div className="pointer-events-none absolute -top-24 -right-10 h-48 w-48 rounded-full bg-fuchsia-400/30 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-28 -left-12 h-56 w-56 rounded-full bg-orange-400/20 blur-3xl" />
+
+        <CardHeader className="relative pb-4">
+          <CardTitle className="flex flex-col gap-3 text-base">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm">
+                <ClipboardList className="w-4 h-4 text-primary drop-shadow-sm" />
+                <span className="font-semibold bg-gradient-to-r from-primary via-fuchsia-500 to-orange-500 bg-clip-text text-transparent">
+                  Plan Assessment Brief
+                </span>
+              </div>
+              <Badge className="bg-gradient-to-r from-primary/80 to-fuchsia-500/80 text-primary-foreground text-[0.65rem] uppercase tracking-wide shadow-sm">
+                {hobbyDev === "hobby" ? "Hobby" : "Enterprise"}
+              </Badge>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-1 font-medium text-primary">
+                <Sparkles className="w-3 h-3" />
+                {planWordCount} plan words
+              </span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-fuchsia-500/15 px-2 py-1 font-medium text-fuchsia-600">
+                <Eye className="w-3 h-3" />
+                {promptWordCount} prompt words
+              </span>
+            </div>
+          </CardTitle>
+        </CardHeader>
+
+        <CardContent className="relative space-y-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-primary">
+              <Sparkles className="w-3.5 h-3.5" />
+              <span className="rounded-full bg-primary/10 px-2 py-1 text-primary">
+                {selectedModels.length === 0
+                  ? "No models selected"
+                  : `${selectedModels.length} model${selectedModels.length === 1 ? "" : "s"} selected`}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              {selectedModels.length > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 border-primary/40 text-primary hover:bg-primary/10"
+                  onClick={onClearAllModels}
+                >
+                  Clear
+                </Button>
+              )}
+              <FloatingModelPicker
+                models={models}
+                selectedModels={selectedModels}
+                onToggleModel={onToggleModel}
+                onSelectAllModels={onSelectAllModels}
+                onClearAllModels={onClearAllModels}
+                disabled={modelsLoading}
+                trigger={modelPickerTrigger}
+              />
+            </div>
+          </div>
+
+          <Separator className="bg-gradient-to-r from-primary/30 via-transparent to-fuchsia-300/30" />
+
+          <div className="grid grid-cols-1 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <Label className="text-xs uppercase tracking-wide text-primary">Project Type</Label>
+                <Select value={hobbyDev} onValueChange={(value) => onHobbyDevChange(value as "hobby" | "enterprise")}>
+                  <SelectTrigger className="w-full h-9 text-sm border-primary/30 bg-background/80 backdrop-blur-sm">
+                    <SelectValue placeholder="Select project type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="hobby">Hobby</SelectItem>
+                    <SelectItem value="enterprise">Enterprise</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="md:col-span-2">
+                <Label className="text-xs uppercase tracking-wide text-fuchsia-600">Constraints</Label>
+                <Textarea
+                  rows={2}
+                  value={constraints}
+                  onChange={(event) => onConstraintsChange(event.target.value)}
+                  placeholder="Any constraints (timeline, budget, compliance, tech stack)"
+                  className="text-sm border-primary/20 bg-background/70 backdrop-blur-sm focus-visible:ring-2 focus-visible:ring-primary/30"
+                />
+              </div>
+            </div>
+
+            <div>
+              <Label className="text-xs uppercase tracking-wide text-orange-600">Plan (Markdown or text)</Label>
+              <Textarea
+                rows={10}
+                value={planMarkdown}
+                onChange={(event) => onPlanMarkdownChange(event.target.value)}
+                placeholder="Paste or write the plan to assess..."
+                className="text-sm border-primary/25 bg-background/75 backdrop-blur focus-visible:ring-2 focus-visible:ring-fuchsia-400/40"
+              />
+            </div>
+
+            <div>
+              <Label className="text-xs uppercase tracking-wide text-primary">Context (optional)</Label>
+              <Textarea
+                rows={3}
+                value={contextSummary}
+                onChange={(event) => onContextSummaryChange(event.target.value)}
+                placeholder="Assess my over-confident junior developer's plan. What is missing?"
+                className="text-sm border-primary/20 bg-background/75 backdrop-blur focus-visible:ring-2 focus-visible:ring-orange-400/40"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              {modelsLoading ? (
+                Array.from({ length: 4 }).map((_, index) => (
+                  <Skeleton key={index} className="h-8 w-28 rounded-full bg-primary/20" />
+                ))
+              ) : selectedModelObjects.length === 0 ? (
+                <p className="text-xs text-primary/80">Selected models will appear here as vibrant pills once added.</p>
+              ) : (
+                selectedModelObjects.map((model) => (
+                  <ModelPill
+                    key={model.id}
+                    model={model}
+                    isLoading={loadingModels.has(model.id)}
+                    hasResponse={Boolean(responses[model.id])}
+                    onRemove={onToggleModel}
+                    variant="compact"
+                  />
+                ))
+              )}
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="text-xs text-primary font-medium">
+                {disableSubmitReason
+                  ? disableSubmitReason
+                  : canSubmit
+                    ? "Ready to assess the plan"
+                    : "Add plan details and choose models to begin"}
+              </div>
+              <Button
+                onClick={onSubmit}
+                disabled={!canSubmit || isSubmitting}
+                size="sm"
+                className="gap-2 bg-gradient-to-r from-primary via-fuchsia-500 to-orange-400 text-primary-foreground shadow-lg hover:brightness-105"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="w-3 h-3 animate-spin" />
+                    <span className="text-sm">Assessing...</span>
+                  </>
+                ) : (
+                  <>
+                    <Zap className="w-3 h-3" />
+                    <span className="text-sm">Assess Plan</span>
+                  </>
+                )}
+              </Button>
+            </div>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs px-3 text-primary hover:bg-primary/10"
+              onClick={() => setShowPromptPreview((prev) => !prev)}
+            >
+              <Eye className="w-3 h-3 mr-1" />
+              {showPromptPreview ? "Hide" : "Show"} Prompt Preview
+            </Button>
+
+            {showPromptPreview && (
+              <div className="rounded-md border border-primary/20 bg-primary/5 p-3 text-xs font-mono whitespace-pre-wrap">
+                {finalPrompt}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/plan-assessment.tsx
+++ b/client/src/pages/plan-assessment.tsx
@@ -1,340 +1,153 @@
 /**
- * Plan Assessment Page – Reuses existing compare flow to let multiple models critique a plan
- *
- * What this file does: Provides a UI for entering a plan and context, selecting models,
- * and submitting a composed "Assess This Plan" prompt to each selected model in parallel.
- * How it works: Mirrors the Home compare page's selection and response rendering using
- * existing components: AppNavigation, ModelButton, ResponseCard, ExportButton. Builds the
- * final prompt from the user's inputs per the default template provided by the user.
- * How the project uses it: Adds the new mode route "/plan-assessment" to evaluate plans
- * across models without introducing new APIs (uses /api/models/respond like Home).
- *
- * Author: Cascade
- * Date: 2025-08-17
+ * Author: gpt-5-codex
+ * Date: 2025-10-18 20:10 UTC
+ * PURPOSE: Plan assessment mode page aligned with the compare layout. Reuses the
+ *          shared comparison hook, floating model picker, and results grid while
+ *          adding plan-specific form inputs to build the assessment prompt.
+ *          Updated to pre-select the colorful default trio of models for a
+ *          vibrant first-run experience.
+ * SRP/DRY check: Pass - Page orchestrates plan assessment flow via shared
+ *                components without duplicating mutation logic.
  */
 
-import { useMemo, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Brain } from "lucide-react";
 import { AppNavigation } from "@/components/AppNavigation";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { ModelButton } from "@/components/ModelButton";
-import { ResponseCard } from "@/components/ResponseCard";
-import { ExportButton } from "@/components/ExportButton";
-import { Brain, ClipboardList, Zap } from "lucide-react";
+import { PlanAssessmentHero } from "@/components/plan-assessment/PlanAssessmentHero";
+import { ComparisonResults } from "@/components/comparison/ComparisonResults";
+import { useComparison } from "@/hooks/useComparison";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
-import type { AIModel, ModelResponse } from "@/types/ai-models";
+import type { AIModel } from "@/types/ai-models";
 
 export default function PlanAssessmentPage() {
   const { toast } = useToast();
-
-  // Inputs per the user's default template
-  const [hobbyDev, setHobbyDev] = useState<string>("enterprise"); // "hobby" | "enterprise"
+  const [projectType, setProjectType] = useState<"hobby" | "enterprise">("enterprise");
   const [constraints, setConstraints] = useState<string>("");
   const [planMarkdown, setPlanMarkdown] = useState<string>("");
   const [contextSummary, setContextSummary] = useState<string>("");
+  const [initialModelsSelected, setInitialModelsSelected] = useState<boolean>(false);
 
-  const [selectedModels, setSelectedModels] = useState<string[]>([]);
-  const [responses, setResponses] = useState<Record<string, ModelResponse>>({});
-  const [loadingModels, setLoadingModels] = useState<Set<string>>(new Set());
-  const [completedModels, setCompletedModels] = useState<Set<string>>(new Set());
-  const [showTiming, setShowTiming] = useState(true);
+  const { state, actions, status } = useComparison();
 
-  // Models
   const { data: models = [], isLoading: modelsLoading } = useQuery({
     queryKey: ["/api/models"],
     queryFn: async () => {
-      const res = await fetch("/api/models");
-      if (!res.ok) throw new Error("Failed to fetch models");
-      return res.json() as Promise<AIModel[]>;
+      const response = await fetch("/api/models");
+      if (!response.ok) throw new Error("Failed to fetch models");
+      return response.json() as Promise<AIModel[]>;
     },
   });
 
-  // Compose the final prompt from inputs (default template from the user)
+  useEffect(() => {
+    if (!initialModelsSelected && models.length > 0 && state.selectedModels.length === 0) {
+      const preferredDefaults = [
+        "gpt-5-mini-2025-08-07",
+        "gpt-5-nano-2025-08-07",
+        "claude-haiku-4-5-20251015",
+      ];
+
+      const availableDefaults = preferredDefaults.filter((modelId) =>
+        models.some((model) => model.id === modelId),
+      );
+
+      if (availableDefaults.length > 0) {
+        actions.selectAllModels(availableDefaults);
+        setInitialModelsSelected(true);
+      }
+    }
+  }, [models, state.selectedModels.length, initialModelsSelected, actions]);
+
   const finalPrompt = useMemo(() => {
     const lines: string[] = [
       "## Assess This Plan",
-      "You are the senior developer on the project.  Assess the Junior Developer's plan and provide feedback.  Do not use code snippets.  Assume the Junior Developer is already an expert who simply forgot, do not 'teach' them.  Be concise and to the point.",
-      `{HobbyDev} ${hobbyDev === "hobby" ? "Hobby dev" : "enterprise"} level?`,
-      `{Constraints} ${constraints || "(none provided)"}`,
+      "You are the senior developer on the project. Assess the Junior Developer's plan and provide feedback. Do not use code snippets. Assume the Junior Developer is already an expert who simply forgot, do not 'teach' them. Be concise and to the point.",
+      `{HobbyDev} ${projectType === "hobby" ? "Hobby dev" : "Enterprise"} level?`,
+      `{Constraints} ${constraints.trim() || "(none provided)"}`,
       `{PlanMarkdown}\n${planMarkdown.trim()}`,
-      `{ContextSummary|} ${contextSummary || ""}`,
+      `{ContextSummary|} ${contextSummary.trim()}`,
     ];
+
     return lines.join("\n");
-  }, [hobbyDev, constraints, planMarkdown, contextSummary]);
+  }, [projectType, constraints, planMarkdown, contextSummary]);
 
-  // Mutation to request per-model response, same as Home
-  const modelResponseMutation = useMutation({
-    mutationFn: async (data: { prompt: string; modelId: string }) => {
-      const response = await apiRequest("POST", "/api/models/respond", data);
-      const responseData = (await response.json()) as ModelResponse;
-      return { modelId: data.modelId, response: responseData };
-    },
-    onSuccess: (data) => {
-      const responseWithStatus = { ...data.response, status: "success" as const };
-      setResponses((prev) => ({ ...prev, [data.modelId]: responseWithStatus }));
-      setLoadingModels((prev) => {
-        const ns = new Set(prev);
-        ns.delete(data.modelId);
-        return ns;
-      });
-      setCompletedModels((prev) => new Set([...Array.from(prev), data.modelId]));
+  const hasPlan = planMarkdown.trim().length > 0;
+  const canSubmit = hasPlan && status.canStartComparison(finalPrompt);
+  const disableSubmitReason = !hasPlan
+    ? "Provide plan content to generate critiques"
+    : state.selectedModels.length === 0
+      ? "Select at least one model"
+      : status.isComparing
+        ? "Assessment in progress"
+        : undefined;
 
-      const model = models.find((m) => m.id === data.modelId);
+  const handleAssess = () => {
+    if (!hasPlan) {
       toast({
-        title: `${model?.name || "Model"} Responded`,
-        description: `Response received in ${(data.response.responseTime / 1000).toFixed(1)}s`,
+        title: "Add a plan", 
+        description: "Paste or write the plan to assess before requesting critiques.",
+        variant: "destructive",
       });
-    },
-    onError: (error: any, variables) => {
-      setLoadingModels((prev) => {
-        const ns = new Set(prev);
-        ns.delete(variables.modelId);
-        return ns;
-      });
-      setResponses((prev) => ({
-        ...prev,
-        [variables.modelId]: {
-          content: "",
-          status: "error" as const,
-          responseTime: 0,
-          error: error.message,
-        },
-      }));
-      const model = models.find((m) => m.id === variables.modelId);
-      toast({ title: `${model?.name || "Model"} Failed`, description: error.message, variant: "destructive" });
-    },
-  });
-
-  const handleSubmit = () => {
-    if (!planMarkdown.trim()) {
-      toast({ title: "Enter a plan", description: "Paste or write a plan to assess.", variant: "destructive" });
-      return;
-    }
-    if (selectedModels.length === 0) {
-      toast({ title: "Select models", description: "Choose at least one model.", variant: "destructive" });
       return;
     }
 
-    setResponses({});
-    setLoadingModels(new Set(selectedModels));
-    setCompletedModels(new Set());
-    selectedModels.forEach((modelId) => modelResponseMutation.mutate({ prompt: finalPrompt, modelId }));
-    toast({ title: "Assessment Started", description: `Requesting critiques from ${selectedModels.length} models...` });
+    if (state.selectedModels.length === 0) {
+      toast({
+        title: "Select models",
+        description: "Choose at least one model to run the assessment.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    actions.startComparison(finalPrompt);
   };
 
-  const retryModel = (modelId: string) => {
-    if (!planMarkdown.trim()) return;
-    setLoadingModels((prev) => new Set([...Array.from(prev), modelId]));
-    setCompletedModels((prev) => {
-      const ns = new Set(prev);
-      ns.delete(modelId);
-      return ns;
-    });
-    setResponses((prev) => {
-      const nr = { ...prev };
-      delete nr[modelId];
-      return nr;
-    });
-    modelResponseMutation.mutate({ prompt: finalPrompt, modelId });
+  const handleRetry = (modelId: string) => {
+    actions.retryModel(modelId, finalPrompt);
   };
-
-  const selectedModelData = models.filter((m) => selectedModels.includes(m.id));
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-background flex flex-col">
       <AppNavigation title="Plan Assessment" subtitle="Have multiple models critique a plan" icon={Brain} />
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-        <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-          {/* Model selection */}
-          <div className="xl:col-span-1">
-            <div className="space-y-4">
-              <Card>
-                <CardHeader className="pb-4">
-                  <CardTitle className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <Brain className="w-5 h-5 text-blue-600" />
-                      <span>AI Models</span>
-                    </div>
-                    <div className="text-sm text-gray-500">{selectedModels.length} selected</div>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4 pt-0">
-                  {modelsLoading ? (
-                    <div className="grid grid-cols-1 gap-3">
-                      {[...Array(6)].map((_, i) => (
-                        <div key={i} className="h-20 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="space-y-4">
-                      {Object.entries(
-                        models.reduce((acc, model) => {
-                          if (!acc[model.provider]) acc[model.provider] = [] as AIModel[];
-                          (acc[model.provider] as AIModel[]).push(model);
-                          return acc;
-                        }, {} as Record<string, AIModel[]>)
-                      ).map(([provider, providerModels]) => (
-                        <div key={provider} className="space-y-2">
-                          <div className="flex items-center justify-between">
-                            <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200">{provider}</h3>
-                            <div className="flex gap-1">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => {
-                                  const ids = (providerModels as AIModel[]).map((m) => m.id);
-                                  const allSelected = ids.every((id) => selectedModels.includes(id));
-                                  if (allSelected) {
-                                    setSelectedModels((prev) => prev.filter((id) => !ids.includes(id)));
-                                  } else {
-                                    setSelectedModels((prev) => Array.from(new Set([...prev, ...ids])));
-                                  }
-                                }}
-                                className="text-xs h-6 px-2"
-                              >
-                                {(providerModels as AIModel[]).every((m) => selectedModels.includes(m.id)) ? "None" : "All"}
-                              </Button>
-                            </div>
-                          </div>
-                          <div className="grid grid-cols-1 gap-2">
-                            {(providerModels as AIModel[]).map((model) => (
-                              <ModelButton
-                                key={model.id}
-                                model={model}
-                                isSelected={selectedModels.includes(model.id)}
-                                isAnalyzing={loadingModels.has(model.id)}
-                                responseCount={responses[model.id] ? 1 : 0}
-                                onToggle={(modelId) => {
-                                  setSelectedModels((prev) =>
-                                    prev.includes(modelId) ? prev.filter((id) => id !== modelId) : [...prev, modelId]
-                                  );
-                                }}
-                                disabled={loadingModels.has(model.id)}
-                                showTiming={showTiming}
-                              />
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-          </div>
+      <div className="flex-1">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+          <PlanAssessmentHero
+            finalPrompt={finalPrompt}
+            hobbyDev={projectType}
+            onHobbyDevChange={setProjectType}
+            constraints={constraints}
+            onConstraintsChange={setConstraints}
+            planMarkdown={planMarkdown}
+            onPlanMarkdownChange={setPlanMarkdown}
+            contextSummary={contextSummary}
+            onContextSummaryChange={setContextSummary}
+            models={models}
+            modelsLoading={modelsLoading}
+            selectedModels={state.selectedModels}
+            loadingModels={state.loadingModels}
+            responses={state.responses}
+            onToggleModel={actions.toggleModel}
+            onSelectAllModels={actions.selectAllModels}
+            onClearAllModels={actions.clearAllModels}
+            onSubmit={handleAssess}
+            canSubmit={canSubmit}
+            isSubmitting={status.isComparing}
+            disableSubmitReason={disableSubmitReason}
+          />
 
-          {/* Main content */}
-          <div className="xl:col-span-2 space-y-4">
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center space-x-2 text-sm">
-                  <ClipboardList className="w-4 h-4" />
-                  <span>Plan and Context</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 pt-0">
-                {/* Hobby vs Enterprise */}
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                  <div>
-                    <Label className="text-xs">Project Type</Label>
-                    <Select value={hobbyDev} onValueChange={setHobbyDev}>
-                      <SelectTrigger className="w-full h-9">
-                        <SelectValue placeholder="Select project type" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="hobby">Hobby</SelectItem>
-                        <SelectItem value="enterprise">Enterprise</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="md:col-span-2">
-                    <Label className="text-xs">Constraints</Label>
-                    <Textarea
-                      rows={2}
-                      value={constraints}
-                      onChange={(e) => setConstraints(e.target.value)}
-                      placeholder="Any constraints (time, budget, compliance, stack)"
-                    />
-                  </div>
-                </div>
-
-                {/* Plan */}
-                <div>
-                  <Label className="text-xs">Plan (Markdown or text)</Label>
-                  <Textarea
-                    rows={10}
-                    value={planMarkdown}
-                    onChange={(e) => setPlanMarkdown(e.target.value)}
-                    placeholder="Paste or write the plan to assess..."
-                  />
-                </div>
-
-                {/* Context */}
-                <div>
-                  <Label className="text-xs">Context (optional)</Label>
-                  <Textarea
-                    rows={3}
-                    value={contextSummary}
-                    onChange={(e) => setContextSummary(e.target.value)}
-                    placeholder="Assess my over-confident junior developer's plan.  What are the key insights he is missing?"
-                  />
-                </div>
-
-                <div className="flex justify-between items-center">
-                  <div className="text-xs text-gray-600 dark:text-gray-400">
-                    {selectedModels.length === 0 ? "Select models to request assessments" : `Ready to assess with ${selectedModels.length} model${selectedModels.length !== 1 ? "s" : ""}`}
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <ExportButton
-                      prompt={finalPrompt}
-                      models={selectedModelData}
-                      responses={responses}
-                      disabled={loadingModels.size > 0}
-                    />
-                    <Button
-                      onClick={handleSubmit}
-                      disabled={loadingModels.size > 0 || !planMarkdown.trim() || selectedModels.length === 0}
-                      className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2"
-                      size="sm"
-                    >
-                      {loadingModels.size > 0 ? (
-                        <>
-                          <div className="w-3 h-3 mr-1 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                          <span className="text-sm">Assessing...</span>
-                        </>
-                      ) : (
-                        <>
-                          <Zap className="w-3 h-3 mr-1" />
-                          <span className="text-sm">Assess Plan</span>
-                        </>
-                      )}
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Results */}
-            {selectedModelData.length > 0 && (
-              <div className="grid grid-cols-1 gap-4">
-                {selectedModelData.map((model) => (
-                  <ResponseCard
-                    key={model.id}
-                    model={model}
-                    response={responses[model.id]}
-                    onRetry={() => retryModel(model.id)}
-                    showTiming={showTiming}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
+          {(status.isComparing || status.hasResponses) && (
+            <ComparisonResults
+              models={models}
+              responses={state.responses}
+              selectedModels={state.selectedModels}
+              onRetry={handleRetry}
+              showTiming={true}
+              prompt={finalPrompt}
+              isComparing={status.isComparing}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/docs/2025-10-18-plan-plan-assessment-alignment.md
+++ b/docs/2025-10-18-plan-plan-assessment-alignment.md
@@ -1,0 +1,25 @@
+<!--
+Author: gpt-5-codex
+Date: 2025-10-18T18:40:00Z
+PURPOSE: Document plan to realign plan assessment page UI with compare page layout, ensuring consistent model selection and results presentation while reusing shared components.
+SRP/DRY check: Pass - Planning document focused solely on outlining upcoming work.
+-->
+
+# Plan Assessment Page Alignment Plan
+
+**Date:** 2025-10-18T18:40:00Z
+
+## Goal
+- Rework `client/src/pages/plan-assessment.tsx` to mirror the modern compare experience with hero prompt area styling and shared comparison components.
+
+## To-Do
+- [ ] Audit existing compare flow (`EnhancedPromptArea`, `ComparisonResults`, `useComparison`) for reusable pieces that can support plan assessment inputs.
+- [ ] Create a dedicated hero form component that captures plan fields (project type, constraints, plan markdown, optional context) while embedding floating model picker and action controls consistent with compare page.
+- [ ] Update `plan-assessment.tsx` to leverage `useComparison`, new hero form, and shared `ComparisonResults` for responses/export handling.
+- [ ] Ensure visual alignment with compare page spacing, background, and typography; remove legacy sidebar grid layout.
+- [ ] Verify prompt composition remains accurate and responses trigger correctly for selected models.
+
+## Notes
+- Preserve plan-specific template lines but surface preview/character counts similar to compare experience for user confidence.
+- When wiring actions, reuse toast handling inside `useComparison` to avoid duplicate mutation logic in the page.
+- Maintain export support via `ComparisonResults` while passing the constructed prompt string.

--- a/docs/2025-10-18-plan-plan-assessment-polish.md
+++ b/docs/2025-10-18-plan-plan-assessment-polish.md
@@ -1,0 +1,26 @@
+<!--
+Author: gpt-5-codex
+Date: 2025-10-18 20:10 UTC
+PURPOSE: Capture the plan for infusing the plan assessment hero with colorful accents
+         and ensuring default model preselection while keeping SRP/DRY alignment.
+SRP/DRY check: Pass - Documentation only, references existing components without duplicating logic.
+-->
+
+# Plan: Plan Assessment Polish
+
+## Goals
+- Preselect the "Plan Trio" models (gpt-5-mini, gpt-5-nano, Haiku 4.5) so users see critiques immediately.
+- Introduce more vibrant gradients, colorful buttons, and energetic pills in the plan hero.
+- Preserve existing shared comparison flow while elevating first-run visual delight.
+
+## Tasks
+1. Update `plan-assessment.tsx` to seed the default trio once models load.
+2. Refresh `PlanAssessmentHero` styling with gradients, colorful badges, and expressive controls.
+3. Verify pills, buttons, and prompt preview align with the new accent palette.
+4. Run `npm run check` to confirm TypeScript health.
+
+## Risks & Notes
+- Ensure model IDs include release suffixes (`-2025-08-07`, `-20251015`).
+- Avoid regressing accessibility: maintain contrast and readable font sizes.
+- Gradient layers should remain decorative (pointer-events none) to keep interactions smooth.
+


### PR DESCRIPTION
## Summary
- preselect gpt-5-mini, gpt-5-nano, and Haiku 4.5 when the plan assessment models load
- refresh the plan assessment hero with gradient backgrounds, colorful badges, and vibrant buttons
- document the polish plan for the plan assessment page in the docs folder

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f3ddf04a4c8326a62ee5f638552323