### PR TITLE
Refine debate prompt streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.12] - 2025-10-18
+
+### Changed
+- **Debate Prompt Integration:** Updated `server/routes/debate.routes.ts` and `server/providers/openai.ts` to send debate turns
+  through the stored OpenAI prompt `pmpt_6856e018a02c8196aa1ccd7eac56ee020cbd4441b7c750b1`, forwarding topic, position, and
+  intensity variables as strings while preserving cross-provider streaming fallbacks.
+- **Provider Prompt Options:** Extended `server/providers/base.ts` prompt typings so both streaming and non-streaming calls can
+  share the stored prompt reference contract across providers.
+
 ## [Version 0.4.11] - 2025-10-17
 
 ### Changed

--- a/docs/2025-10-18-plan-debate-prompt-integration.md
+++ b/docs/2025-10-18-plan-debate-prompt-integration.md
@@ -1,0 +1,26 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-18 22:01 UTC
+ * PURPOSE: Outline implementation steps to align debate streaming with OpenAI stored prompt usage,
+ *          ensuring adversarial intensity variables are injected via the unified variable pipeline and
+ *          Responses API prompt references follow the expected shape.
+ * SRP/DRY check: Pass - Document scopes planning details for this change only, referencing existing modules without duplication.
+ */
+
+# Plan: Debate Prompt Integration
+
+## Goals
+- Use the OpenAI stored prompt `pmpt_6856e018a02c8196aa1ccd7eac56ee020cbd4441b7c750b1` for debate turns.
+- Ensure adversarial intensity, position, and topic variables flow as strings through the server/provider stack.
+- Maintain compatibility with existing providers and the streaming harness.
+
+## Tasks
+1. Extend provider call options (non-streaming & streaming) to accept optional prompt references with variables.
+2. Update the OpenAI provider to forward prompt references to `openai.responses.create` and `responses.stream` while preserving retries, reasoning config, and fallback logic.
+3. Modify the debate streaming route to compute position/intensity/topic variables, pass them as strings, and prefer the stored prompt while retaining message fallbacks for non-OpenAI providers.
+4. Verify front-end streaming options already provide required fields; adjust if additional parameters (e.g., position) must cross the network explicitly.
+5. Document the change (CHANGELOG) and ensure plan completion notes.
+
+## Validation
+- Manual sanity check via `npm run test` (or targeted debate stream tests) if runtime available.
+- Confirm TypeScript types compile and lint without errors.

--- a/server/providers/base.ts
+++ b/server/providers/base.ts
@@ -76,6 +76,12 @@ export interface ModelMessage {
   metadata?: Record<string, any>;
 }
 
+export interface PromptReference {
+  id: string;
+  version: string;
+  variables?: Record<string, string>;
+}
+
 /**
  * Call options for model invocation
  * Provides fine-grained control over model behavior
@@ -97,6 +103,8 @@ export interface CallOptions {
     summary?: 'auto' | 'detailed';
     verbosity?: 'low' | 'medium' | 'high';
   };
+  /** Optional stored prompt reference with variable payload */
+  prompt?: PromptReference;
 }
 
 export interface StreamingCompleteExtras {
@@ -133,6 +141,8 @@ export interface StreamingCallOptions {
   };
   /** Optional Responses API instructions steering */
   instructions?: string;
+  /** Optional stored prompt reference with variable payload */
+  prompt?: PromptReference;
   onReasoningChunk: (chunk: string) => void;
   onContentChunk: (chunk: string) => void;
   onJsonChunk?: (chunk: unknown) => void;


### PR DESCRIPTION
## Summary
- route debate streaming through the stored OpenAI prompt so topic, position, and intensity flow as string variables
- extend the provider base/OpenAI implementation to accept prompt references for both standard and streaming responses
- document the prompt integration plan and update the changelog entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f40d7208a48326b6c9347dd58098da