### PR TITLE
Sync debate prompt docs with role variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 # Changelog
 <!--
  * Author: GPT-5 Codex
- * Date: 2025-10-18 00:50 UTC
+ * Date: 2025-10-19 00:34 UTC
  * PURPOSE: Maintain a human-readable history of notable changes for releases and audits.
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
+
+## [Version 0.4.13] - 2025-10-19
+
+### Changed
+- **Debate Prompt Variables:** Propagated the debate role through streaming provider prompts and updated
+  `tests/server/debate-handshake.test.ts` to assert the role metadata reaches providers.
+- **Documentation Sync:** Refreshed `client/public/docs/debate-prompts.md` so the documented prompt
+  variables (role, position, topic, intensity) match the server contract and clarified rebuttal message
+  handling.
+- **Planning Artifact:** Extended `docs/2025-10-18-plan-debate-variables.md` to cover documentation and
+  changelog follow-ups for traceability.
 
 ## [Version 0.4.12] - 2025-10-18
 

--- a/client/public/docs/debate-prompts.md
+++ b/client/public/docs/debate-prompts.md
@@ -1,3 +1,9 @@
+* Author: GPT-5 Codex
+* Date: 2025-10-19 00:30 UTC
+* PURPOSE: Document the active debate prompt templates, variable contract, and intensity guidance for
+*          debate streaming so provider templates remain in sync with server expectations.
+* SRP/DRY check: Pass - Markdown strictly tracks debate prompt guidance without overlapping other docs.
+
 # Debate Mode Prompts - Robert's Rules of Order
 
 Author: Cascade
@@ -132,7 +138,7 @@ The weight of evidence and logic compels us to {conclusion}.
 ```
 You are responding to your opponent's previous argument as the {role} debater arguing {position} the proposition: "{topic}"
 
-Your opponent just said: "{response}"
+Your opponent's latest statement is quoted above inside the prompt body.
 
 Structure your rebuttal by:
 1. Identifying the key weaknesses in your opponent's argument
@@ -159,16 +165,18 @@ I urge you to reject my opponent's flawed reasoning and embrace the compelling c
 ## Usage Instructions for Developers
 
 ### Prompt Template Variables:
-- `{role}` - "AFFIRMATIVE" or "NEGATIVE"  
-- `{position}` - "FOR" or "AGAINST"
-- `{topic}` - The full debate proposition
-- `{intensity}` - Adversarial level (1-4)
-- `{response}` - Previous opponent's argument
-- `{originalPrompt}` - The debate topic for reference
+- `{role}` - "AFFIRMATIVE" or "NEGATIVE" debate assignment forwarded with every provider request
+- `{position}` - "FOR" (affirmative) or "AGAINST" (negative) stance supplied alongside the role
+- `{topic}` - The full debate proposition text provided by the session initializer
+- `{intensity}` - Adversarial level (1-4) mirrored from the session adversarial slider
+
+> **Note:** Provider templates must rely on these four variables exclusively. The opponent's latest
+> argument is delivered inline within the message body for rebuttal turns rather than as a prompt
+> variable. Historical `{response}` or `{originalPrompt}` placeholders no longer populate.
 
 ### Implementation Notes:
-- Model 1 always gets AFFIRMATIVE (Pro) role
-- Model 2 always gets NEGATIVE (Con) role  
-- Intensity setting affects both models equally
-- Topics can be selected from list or custom input by user
-- Follow Robert's Rules structure: Opening → Rebuttals → Closing
+- Model 1 always gets AFFIRMATIVE (Pro) role and `{position}` of `FOR`
+- Model 2 always gets NEGATIVE (Con) role and `{position}` of `AGAINST`
+- Intensity setting affects both models equally and maps directly to `{intensity}`
+- Topics can be selected from list or custom input by user and populate `{topic}`
+- Follow Robert's Rules structure: Opening → Rebuttals → Closing to match streaming prompts

--- a/docs/2025-10-18-plan-debate-variables.md
+++ b/docs/2025-10-18-plan-debate-variables.md
@@ -1,0 +1,19 @@
+* Author: GPT-5 Codex
+* Date: 2025-10-19 00:32 UTC
+* PURPOSE: Document the concise plan, tasks, and verification steps for extending debate stream prompt variables, syncing documentation, and updating regression coverage.
+* SRP/DRY check: Pass - Planning note dedicated to debate prompt variable enhancement; no redundant instructions.
+
+## Goal
+Ensure debate stream prompts propagate the debating role to providers and add regression coverage verifying the handshake forwards the role metadata.
+
+## Tasks
+- Inspect `server/routes/debate.routes.ts` to understand how prompt variables are assembled prior to invoking provider streaming APIs.
+- Update the prompt variable map so the debated role propagates alongside other debate metadata.
+- Extend `tests/server/debate-handshake.test.ts` to assert the mocked provider receives the new role variable.
+- Sync `client/public/docs/debate-prompts.md` with the prompt variable contract (role, topic, position, intensity).
+- Update `CHANGELOG.md` with the debate variable propagation summary for release tracking.
+- Execute the targeted Vitest suite to confirm streaming handshake behavior remains intact.
+
+## Validation
+- Run `npm run test -- debate-handshake` to execute the focused Vitest scenario.
+- Review git diff to confirm only intended files changed.

--- a/server/routes/debate.routes.ts
+++ b/server/routes/debate.routes.ts
@@ -302,6 +302,7 @@ async function streamDebateTurn(harness: StreamHarness, payload: DebateStreamPay
       intensity: String(payload.intensity),
       position: payload.position,
       topic: payload.topic,
+      role: payload.role,
     };
 
     harness.status("resolving_provider", undefined, { modelId: payload.modelId });

--- a/tests/server/debate-handshake.test.ts
+++ b/tests/server/debate-handshake.test.ts
@@ -185,6 +185,8 @@ describe('Debate streaming handshake', () => {
     expect(statusEvent?.data?.phase).toBeDefined();
 
     expect(providerStreamMock).toHaveBeenCalledTimes(1);
+    const providerCall = providerStreamMock.mock.calls[0]?.[0];
+    expect(providerCall?.prompt?.variables?.role).toBe('AFFIRMATIVE');
 
     const persisted = await storage.storage.getDebateSession(sessionInfo.id);
     expect(persisted).toBeTruthy();


### PR DESCRIPTION
## Summary
- align the debate prompt documentation with the current role/position/topic/intensity variable contract
- extend the planning note to track the documentation and changelog follow-ups
- record the debate prompt sync in the changelog for version 0.4.13

## Testing
- OPENAI_API_KEY=dummy STRIPE_SECRET_KEY=sk_test_dummy npx vitest run tests/server/debate-handshake.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f42599db6c8326866c46f4e76ff7e5