### PR TITLE
Align debate prompt messaging with shared intensity descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.16] - 2025-10-19 01:10 UTC
+
+### Changed
+- **Debate Prompt Context:** Refactored `server/routes/debate.routes.ts` to load shared debate instructions, send developer/system/user
+  messages without redundancy, and forward textual adversarial guidance in `prompt.variables`.
+- **Shared Prompt Utilities:** Moved debate prompt parsing and template token replacement into `shared/` so both the client hook
+  and server streaming route reuse the same intensity descriptors and placeholder handling.
+
+### Documentation
+- Logged the debate intensity alignment plan in `docs/2025-10-19-plan-debate-intensity-alignment.md` for traceability.
+
 ## [Version 0.4.15] - 2025-10-18 22:20 UTC
 
 ### Fixed

--- a/client/src/components/debate/AdversarialLevelSelector.tsx
+++ b/client/src/components/debate/AdversarialLevelSelector.tsx
@@ -45,23 +45,31 @@ export function AdversarialLevelSelector({
       </div>
 
       <div className="space-y-3">
-        {adversarialLevels.map((level) => (
-          <div key={level.id} className="flex items-center space-x-2">
-            <input
-              type="radio"
-              id={`level-${level.id}`}
-              checked={adversarialLevel === level.id}
-              onChange={() => setAdversarialLevel(level.id)}
-              disabled={disabled}
-            />
-            <label htmlFor={`level-${level.id}`} className="flex-1">
-              <div className="text-sm font-medium">{level.name}</div>
-              <div className="text-xs text-gray-500 line-clamp-2">
-                {debateData?.intensities?.[level.id] || ''}
-              </div>
-            </label>
-          </div>
-        ))}
+        {adversarialLevels.map((level) => {
+          const descriptor = debateData?.intensities?.[level.id];
+          const levelName = descriptor?.label || level.name;
+          const levelGuidance = descriptor?.summary
+            ? `${descriptor.summary}`
+            : descriptor?.guidance || '';
+
+          return (
+            <div key={level.id} className="flex items-center space-x-2">
+              <input
+                type="radio"
+                id={`level-${level.id}`}
+                checked={adversarialLevel === level.id}
+                onChange={() => setAdversarialLevel(level.id)}
+                disabled={disabled}
+              />
+              <label htmlFor={`level-${level.id}`} className="flex-1">
+                <div className="text-sm font-medium">{levelName}</div>
+                <div className="text-xs text-gray-500 line-clamp-2">
+                  {levelGuidance}
+                </div>
+              </label>
+            </div>
+          );
+        })}
       </div>
 
       <div className="p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">

--- a/client/src/lib/debatePromptUtils.ts
+++ b/client/src/lib/debatePromptUtils.ts
@@ -5,7 +5,7 @@
  * SRP/DRY check: Pass - Centralizes prompt token handling without duplicating business logic in hooks or services.
  */
 
-import { replaceTemplatePlaceholders } from "./templateTokens";
+import { replaceTemplatePlaceholders } from "@shared/template-tokens.ts";
 
 export type DebateTemplateReplacements = Record<string, string>;
 

--- a/client/src/lib/promptParser.ts
+++ b/client/src/lib/promptParser.ts
@@ -1,12 +1,19 @@
 /**
  * Prompt Parser Utility
- * 
+ *
  * Parses the compare-prompts.md file to extract prompt categories and templates
  * dynamically, making the prompt system truly modular and extensible.
- * 
+ *
  * Author: Cascade Claude 4 Sonnet Thinking
  * Date: August 11, 2025
  */
+
+import {
+  extractDebateInstructions,
+  type DebateFlowTemplates,
+  type DebateInstructions,
+  type DebateTopic,
+} from '@shared/debate-instructions.ts';
 
 export interface PromptTemplate {
   id: string;
@@ -23,24 +30,7 @@ export interface PromptCategory {
 /**
  * Debate prompt structures parsed from docs/debate-prompts.md
  */
-export interface DebateTopic {
-  id: string;
-  title: string;
-  proposition: string;
-}
-
-export interface DebateFlowTemplates {
-  opening?: string;
-  rebuttal?: string;
-  closing?: string;
-}
-
-export interface DebateInstructions {
-  baseTemplate: string; // contains placeholders like {role},{position},{topic},{intensity}
-  intensities: Record<number, string>; // 1..4
-  topics: DebateTopic[];
-  templates: DebateFlowTemplates;
-}
+export type { DebateTopic, DebateInstructions, DebateFlowTemplates };
 
 /**
  * Parses markdown content to extract prompt categories and templates
@@ -345,85 +335,7 @@ export async function parseDebatePromptsFromMarkdown(): Promise<DebateInstructio
     const response = await fetch('/docs/debate-prompts.md');
     if (!response.ok) throw new Error('Failed to fetch debate-prompts.md');
     const markdown = await response.text();
-
-    const lines = markdown.split('\n');
-
-    // Helpers
-    const collectCodeBlockAfterHeading = (headingMatch: RegExp): string | undefined => {
-      let inSection = false;
-      let inFence = false;
-      const buff: string[] = [];
-      for (let i = 0; i < lines.length; i++) {
-        const raw = lines[i];
-        const line = raw.trim();
-        if (!inSection) {
-          if (headingMatch.test(line)) {
-            inSection = true;
-          }
-          continue;
-        }
-        if (line.startsWith('```')) {
-          if (!inFence) {
-            inFence = true;
-            continue;
-          } else {
-            // closing fence
-            break;
-          }
-        }
-        if (inFence) buff.push(raw.replace(/\r?$/, ''));
-      }
-      const content = buff.join('\n').trim();
-      return content || undefined;
-    };
-
-    // Base Debate Instructions (first code block under "### Base Debate Instructions")
-    const baseTemplate = collectCodeBlockAfterHeading(/^###\s+Base\s+Debate\s+Instructions/i) || '';
-
-    // Intensity levels (Level 1..4 each has a fenced code block under its #### heading)
-    const intensities: Record<number, string> = {};
-    for (let level = 1; level <= 4; level++) {
-      const content = collectCodeBlockAfterHeading(new RegExp(`^####\\s+Level\\s+${level}\\b`, 'i')) || '';
-      intensities[level] = content;
-    }
-
-    // Topics section: iterate under "## Debate Topics", grab each ### heading and its proposition line
-    const topics: DebateTopic[] = [];
-    let inTopics = false;
-    let currentTitle: string | null = null;
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i].trim();
-      if (!inTopics) {
-        if (/^##\s+Debate\s+Topics/i.test(line)) inTopics = true;
-        continue;
-      }
-      if (line.startsWith('## ') && !/^##\s+Debate\s+Topics/i.test(line)) {
-        // reached next major section
-        break;
-      }
-      if (line.startsWith('### ')) {
-        currentTitle = line.substring(4).trim();
-        continue;
-      }
-      if (currentTitle && line.startsWith('**Proposition:**')) {
-        const proposition = line.replace('**Proposition:**', '').trim().replace(/^"|"$/g, '');
-        const id = currentTitle.toLowerCase().replace(/[^a-z0-9]/g, '-');
-        topics.push({ id, title: currentTitle, proposition });
-        currentTitle = null; // wait for next title
-      }
-    }
-
-    // Flow templates section: Opening/Rebuttal/Closing
-    const opening = collectCodeBlockAfterHeading(/^###\s+Opening\s+Statement\s+Template/i);
-    const rebuttal = collectCodeBlockAfterHeading(/^###\s+Rebuttal\s+Template/i);
-    const closing = collectCodeBlockAfterHeading(/^###\s+Closing\s+Argument\s+Template/i);
-
-    return {
-      baseTemplate,
-      intensities,
-      topics,
-      templates: { opening, rebuttal, closing }
-    };
+    return extractDebateInstructions(markdown);
   } catch (err) {
     console.error('Error parsing debate prompts from markdown:', err);
     return null;

--- a/docs/2025-10-19-plan-debate-intensity-alignment.md
+++ b/docs/2025-10-19-plan-debate-intensity-alignment.md
@@ -1,0 +1,21 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-19 00:00 UTC
+ * PURPOSE: Outline adjustments to debate prompt handling so streaming payloads
+ *          reuse shared intensity guidance, avoid duplicate instructions, and
+ *          forward correct variables to OpenAI.
+ * SRP/DRY check: Pass - Focused on debate prompt alignment tasks only.
+ */
+
+# Plan: Debate Intensity Alignment
+
+## Goals
+- Share debate prompt parsing between client and server so both derive intensity guidance from a single source.
+- Ensure server streaming payloads send coherent developer/system/user messages without redundant role/topic statements.
+- Provide OpenAI with textual adversarial guidance instead of numeric levels only.
+
+## Tasks
+1. Extract reusable debate prompt parser utilities into `shared/` for intensity + base template data.
+2. Update client prompt generators/services to consume the shared structures (intensity descriptors, base template replacements).
+3. Refactor server debate route to build developer/system/user messages from shared data, including textual intensity guidance in prompt variables.
+4. Verify provider prompt variable payload matches stored prompt expectations and update documentation/CHANGELOG accordingly.

--- a/shared/debate-instructions.ts
+++ b/shared/debate-instructions.ts
@@ -1,0 +1,201 @@
+/*
+ * Author: gpt-5-codex
+ * Date: 2025-10-19 00:00 UTC
+ * PURPOSE: Expose reusable debate prompt parsing utilities so both client and
+ *          server can derive base templates, intensity descriptors, and topic
+ *          metadata from the canonical markdown source.
+ * SRP/DRY check: Pass - Dedicated to parsing debate instructions without mixing
+ *                transport or storage responsibilities.
+ */
+
+import { replaceTemplatePlaceholders } from "./template-tokens.ts";
+
+export interface DebateTopic {
+  id: string;
+  title: string;
+  proposition: string;
+}
+
+export interface DebateFlowTemplates {
+  opening?: string;
+  rebuttal?: string;
+  closing?: string;
+}
+
+export interface DebateIntensityDescriptor {
+  level: number;
+  label: string;
+  summary?: string;
+  heading: string;
+  guidance: string;
+  fullText: string;
+}
+
+export interface DebateInstructions {
+  baseTemplate: string;
+  intensities: Record<number, DebateIntensityDescriptor>;
+  topics: DebateTopic[];
+  templates: DebateFlowTemplates;
+}
+
+function splitLines(markdown: string): string[] {
+  return markdown.split(/\r?\n/);
+}
+
+function findHeadingIndex(lines: string[], pattern: RegExp): number {
+  for (let i = 0; i < lines.length; i++) {
+    if (pattern.test(lines[i].trim())) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function collectCodeFence(lines: string[], startIndex: number): string {
+  let inFence = false;
+  const buffer: string[] = [];
+
+  for (let i = startIndex; i < lines.length; i++) {
+    const raw = lines[i];
+    const line = raw.trim();
+
+    if (!inFence) {
+      if (line.startsWith("```") || line.startsWith("~~~")) {
+        inFence = true;
+      }
+      continue;
+    }
+
+    if (line.startsWith("```") || line.startsWith("~~~")) {
+      break;
+    }
+
+    buffer.push(raw.replace(/\r?$/, ""));
+  }
+
+  return buffer.join("\n").trim();
+}
+
+function parseIntensityDescriptor(lines: string[], level: number): DebateIntensityDescriptor | undefined {
+  const headingPattern = new RegExp(`^####\\s+Level\\s+${level}\\b`, "i");
+  const headingIndex = findHeadingIndex(lines, headingPattern);
+  if (headingIndex === -1) {
+    return undefined;
+  }
+
+  const headingLine = lines[headingIndex].trim().replace(/^####\s+/, "").trim();
+  const headingWithoutPrefix = headingLine.replace(new RegExp(`^Level\\s+${level}\\s*-\\s*`, "i"), "").trim();
+
+  let label = headingWithoutPrefix;
+  let summary: string | undefined;
+  const summaryMatch = headingWithoutPrefix.match(/^(.*?)\s*\((.+)\)$/);
+  if (summaryMatch) {
+    label = summaryMatch[1].trim();
+    summary = summaryMatch[2].trim();
+  }
+
+  const guidance = collectCodeFence(lines, headingIndex + 1);
+  const fullText = guidance ? `${headingLine}\n${guidance}` : headingLine;
+
+  return {
+    level,
+    label,
+    summary,
+    heading: headingLine,
+    guidance,
+    fullText,
+  };
+}
+
+function parseTopics(lines: string[]): DebateTopic[] {
+  const topics: DebateTopic[] = [];
+  let inTopicsSection = false;
+  let currentTitle: string | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+
+    if (!inTopicsSection) {
+      if (/^##\s+Debate\s+Topics/i.test(trimmed)) {
+        inTopicsSection = true;
+      }
+      continue;
+    }
+
+    if (trimmed.startsWith("## ") && !/^##\s+Debate\s+Topics/i.test(trimmed)) {
+      break;
+    }
+
+    if (trimmed.startsWith("### ")) {
+      currentTitle = trimmed.substring(4).trim();
+      continue;
+    }
+
+    if (currentTitle && trimmed.startsWith("**Proposition:**")) {
+      const proposition = trimmed
+        .replace("**Proposition:**", "")
+        .trim()
+        .replace(/^"|"$/g, "");
+      const id = currentTitle.toLowerCase().replace(/[^a-z0-9]/g, "-");
+      topics.push({ id, title: currentTitle, proposition });
+      currentTitle = null;
+    }
+  }
+
+  return topics;
+}
+
+function parseFlowTemplates(lines: string[]): DebateFlowTemplates {
+  const templateHeadingPatterns: Array<{ key: keyof DebateFlowTemplates; pattern: RegExp }> = [
+    { key: "opening", pattern: /^###\s+Opening\s+Statement\s+Template/i },
+    { key: "rebuttal", pattern: /^###\s+Rebuttal\s+Template/i },
+    { key: "closing", pattern: /^###\s+Closing\s+Argument\s+Template/i },
+  ];
+
+  const templates: DebateFlowTemplates = {};
+
+  for (const entry of templateHeadingPatterns) {
+    const headingIndex = findHeadingIndex(lines, entry.pattern);
+    if (headingIndex !== -1) {
+      templates[entry.key] = collectCodeFence(lines, headingIndex + 1);
+    }
+  }
+
+  return templates;
+}
+
+export function extractDebateInstructions(markdown: string): DebateInstructions {
+  const lines = splitLines(markdown);
+
+  const baseHeadingIndex = findHeadingIndex(lines, /^###\s+Base\s+Debate\s+Instructions/i);
+  const baseTemplate = baseHeadingIndex !== -1 ? collectCodeFence(lines, baseHeadingIndex + 1) : "";
+
+  const intensities: Record<number, DebateIntensityDescriptor> = {};
+  for (let level = 1; level <= 4; level++) {
+    const descriptor = parseIntensityDescriptor(lines, level);
+    if (descriptor) {
+      intensities[level] = descriptor;
+    }
+  }
+
+  return {
+    baseTemplate,
+    intensities,
+    topics: parseTopics(lines),
+    templates: parseFlowTemplates(lines),
+  };
+}
+
+export function getDebateIntensityDescriptor(
+  instructions: DebateInstructions | null | undefined,
+  level: number
+): DebateIntensityDescriptor | null {
+  if (!instructions) {
+    return null;
+  }
+  return instructions.intensities[level] ?? null;
+}
+
+export function formatDebateTemplate(template: string, replacements: Record<string, string>): string {
+  return replaceTemplatePlaceholders(template, replacements);
+}

--- a/shared/template-tokens.ts
+++ b/shared/template-tokens.ts
@@ -1,15 +1,16 @@
 /*
  * Author: gpt-5-codex
- * Date: 2025-10-19 01:18 UTC
- * PURPOSE: Provide case-insensitive placeholder replacement for debate templates while preserving unmatched tokens.
- * SRP/DRY check: Pass - Dedicated utility for placeholder substitution; avoids duplication across hooks/services.
+ * Date: 2025-10-19 00:00 UTC
+ * PURPOSE: Provide case-insensitive placeholder replacement helpers that can be
+ *          shared across client and server modules for debate prompt assembly.
+ * SRP/DRY check: Pass - Focused utility for template substitution only.
  */
 
 const PLACEHOLDER_PATTERN = /{([a-z0-9_]+)}/gi;
 
 export function replaceTemplatePlaceholders(template: string, variables: Record<string, string>): string {
   if (!template) {
-    return '';
+    return "";
   }
 
   if (!variables || Object.keys(variables).length === 0) {


### PR DESCRIPTION
## Summary
- share debate prompt parsing and template token utilities from docs via new `shared/` modules
- refactor debate streaming route to build developer/system/user messages from shared instructions and send textual intensity guidance in prompt variables
- update client debate prompt generators and selectors to consume the shared intensity descriptors and keep UI labels in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f44d3c6e348326abe09acd82d11bf6