### PR TITLE
Fix debate prompt markdown path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.17] - 2025-10-19 03:18 UTC
+
+### Fixed
+- **Debate Prompts Path:** Updated `server/routes/debate.routes.ts` to resolve `client/public/docs/debate-prompts.md` from the process working directory so production bundles continue loading intensity descriptors after moving to `dist/`.
+- **Error Visibility:** Expanded debate prompt load logging to include the resolved path for faster diagnosis when assets are missing.
+
+### Documentation
+- Captured the remediation strategy in `docs/2025-10-19-plan-debate-prompts-path.md`.
+
 ## [Version 0.4.16] - 2025-10-19 01:10 UTC
 
 ### Changed

--- a/docs/2025-10-19-plan-debate-prompts-path.md
+++ b/docs/2025-10-19-plan-debate-prompts-path.md
@@ -1,0 +1,19 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-19 03:16 UTC
+ * PURPOSE: Plan remediation for debate prompt markdown loading so production builds
+ *          resolve assets from a stable root instead of transient bundle directories.
+ * SRP/DRY check: Pass - Focused on path resolution and related verification steps only.
+ */
+
+# Plan: Debate Prompts Path Resolution
+
+## Goals
+- Ensure `server/routes/debate.routes.ts` can resolve `debate-prompts.md` after bundling to `dist/`.
+- Preserve developer/system intensity guidance so debate streams keep descriptive metadata in production.
+- Document and validate the fix with changelog and targeted checks.
+
+## Tasks
+1. Replace the `__dirname`-relative markdown path with a project-root resolver based on `process.cwd()` and reuse it after bundling.
+2. Harden `loadDebateInstructions` to surface the resolved path in error logs for easier debugging while keeping caching intact.
+3. Verify TypeScript types via `npm run check` and update the changelog with a new semantic version entry.

--- a/server/routes/debate.routes.ts
+++ b/server/routes/debate.routes.ts
@@ -1,15 +1,15 @@
 /*
  * Author: GPT-5 Codex
- * Date: 2025-10-18 00:55 UTC
+ * Date: 2025-10-19 03:17 UTC
  * PURPOSE: Align debate streaming routes with the two-stage client contract, providing an init endpoint,
- *          SSE dispatcher, shared streaming logic, and heartbeat keepalives so modern React clients can
- *          consume Responses API streams without premature proxy disconnects while persisting debate turns.
+ *          SSE dispatcher, shared streaming logic, heartbeat keepalives, and resilient asset loading so
+ *          modern React clients can consume Responses API streams without premature proxy disconnects while
+ *          persisting debate turns.
  * SRP/DRY check: Pass - Route module handles debate HTTP concerns only; shared helpers prevent duplication
- *                across init and SSE entry points.
+ *                across init and SSE entry points, including prompt asset resolution.
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { Router } from "express";
 import {
   extractDebateInstructions,
@@ -25,12 +25,8 @@ import { StreamHarness } from "../streaming/stream-harness.js";
 
 const router = Router();
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 const DEBATE_PROMPTS_PATH = path.resolve(
-  __dirname,
-  "..",
-  "..",
+  process.cwd(),
   "client",
   "public",
   "docs",
@@ -51,7 +47,10 @@ function loadDebateInstructions(): DebateInstructions | null {
     return cachedDebateInstructions;
   } catch (error) {
     if (!debateInstructionsLoadErrorLogged) {
-      console.error("Failed to load debate prompts markdown:", error);
+      console.error(
+        `Failed to load debate prompts markdown at ${DEBATE_PROMPTS_PATH}:`,
+        error,
+      );
       debateInstructionsLoadErrorLogged = true;
     }
     return null;


### PR DESCRIPTION
## Summary
- resolve the debate prompts markdown from the process working directory so bundled builds continue loading intensity descriptors
- improve error logging to report the resolved markdown path when the file cannot be read
- document the remediation plan and changelog entry for the debate prompts path fix

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f457b9a9c0832685c1bc911ca40415