### PR TITLE
Harden debate prompt path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.18] - 2025-10-20 04:12 UTC
+
+### Fixed
+- **Debate Prompt Resolution:** Hardened `loadDebateInstructions()` to search stable root candidates (cwd, executable dir, bundler output) and honor `DEBATE_PROMPTS_PATH`, preventing bundled builds from regressing to the debate setup fallback.
+
+### Documentation
+- Captured the follow-up remediation steps in `docs/2025-10-20-plan-debate-prompts-reliability.md`.
+
+## [Version 0.4.17] - 2025-10-19 03:18 UTC
+
+### Fixed
+- **Debate Prompts Path:** Updated `server/routes/debate.routes.ts` to resolve `client/public/docs/debate-prompts.md` from the process working directory so production bundles continue loading intensity descriptors after moving to `dist/`.
+- **Error Visibility:** Expanded debate prompt load logging to include the resolved path for faster diagnosis when assets are missing.
+
+### Documentation
+- Captured the remediation strategy in `docs/2025-10-19-plan-debate-prompts-path.md`.
+
 ## [Version 0.4.16] - 2025-10-19 01:10 UTC
 
 ### Changed

--- a/docs/2025-10-19-plan-debate-prompts-path.md
+++ b/docs/2025-10-19-plan-debate-prompts-path.md
@@ -1,0 +1,19 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-19 03:16 UTC
+ * PURPOSE: Plan remediation for debate prompt markdown loading so production builds
+ *          resolve assets from a stable root instead of transient bundle directories.
+ * SRP/DRY check: Pass - Focused on path resolution and related verification steps only.
+ */
+
+# Plan: Debate Prompts Path Resolution
+
+## Goals
+- Ensure `server/routes/debate.routes.ts` can resolve `debate-prompts.md` after bundling to `dist/`.
+- Preserve developer/system intensity guidance so debate streams keep descriptive metadata in production.
+- Document and validate the fix with changelog and targeted checks.
+
+## Tasks
+1. Replace the `__dirname`-relative markdown path with a project-root resolver based on `process.cwd()` and reuse it after bundling.
+2. Harden `loadDebateInstructions` to surface the resolved path in error logs for easier debugging while keeping caching intact.
+3. Verify TypeScript types via `npm run check` and update the changelog with a new semantic version entry.

--- a/docs/2025-10-20-plan-debate-prompts-reliability.md
+++ b/docs/2025-10-20-plan-debate-prompts-reliability.md
@@ -1,0 +1,21 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-20 04:05 UTC
+ * PURPOSE: Outline a corrective plan for restoring stable debate prompt loading
+ *          after the regression introduced by relying solely on process.cwd().
+ * SRP/DRY check: Pass - Focuses exclusively on locating and caching the debate
+ *                prompt markdown plus verifying no downstream regressions.
+ */
+
+# Plan: Debate Prompt Path Reliability & Race Hardening
+
+## Goals
+- Restore successful loading of `client/public/docs/debate-prompts.md` in both source-driven and bundled deployments.
+- Eliminate the fallback "debate setup" UI regression by ensuring intensity descriptors are delivered consistently.
+- Audit `loadDebateInstructions()` for possible race or cache hazards and implement guards as needed.
+- Capture the fix in the changelog with an updated semantic version entry.
+
+## Tasks
+1. Implement a robust resolver that searches multiple stable roots (explicit env override, cwd, __dirname ancestry, executable dir) for `debate-prompts.md`, caching the discovered path.
+2. Guard `loadDebateInstructions()` with improved logging and fast-fail semantics so a transient read error does not poison future attempts.
+3. Re-test the debate streaming initialization path locally (via `npm run check`) to confirm type safety, and update the changelog documenting the regression fix.


### PR DESCRIPTION
## Summary
- add a multi-root resolver for debate-prompts.md that prefers an env override, cached path, and bundled build directories before falling back
- improve debate prompt load logging to report attempted locations and recover after transient read failures
- document the remediation follow-up plan and record the regression fix in the changelog

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f457b9a9c0832685c1bc911ca40415