### PR TITLE
Fix debate session hydration race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.18] - 2025-10-19 03:58 UTC
+
+### Fixed
+- **Debate Session Hydration:** Stopped `/api/debate/session/:id` refetches from wiping in-progress transcripts by skipping stale turn histories and preserving local response tracking until the server catches up.
+- **Setup Panel Regression:** Guarded debate setup state so the stage view no longer collapses back to the setup panel while the first stream is in flight.
+
+### Documentation
+- Logged the debugging and mitigation steps in `docs/2025-10-19-plan-debate-regression.md`.
+
 ## [Version 0.4.17] - 2025-10-19 03:18 UTC
 
 ### Fixed

--- a/client/src/pages/debate.tsx
+++ b/client/src/pages/debate.tsx
@@ -311,6 +311,24 @@ export default function Debate() {
 
   useEffect(() => {
     if (!sessionDetailsQuery.data || models.length === 0) return;
+
+    const incomingTurnCount = sessionDetailsQuery.data.turnHistory?.length ?? 0;
+    const localMessageCount = debateSession.messages.length;
+    const localTurnCount = debateSession.turnHistory.length;
+    const isSameSession = sessionDetailsQuery.data.id === debateSession.debateSessionId;
+
+    if (
+      isSameSession &&
+      incomingTurnCount > 0 &&
+      incomingTurnCount < Math.max(localMessageCount, localTurnCount)
+    ) {
+      return;
+    }
+
+    if (isSameSession && incomingTurnCount === 0 && (localMessageCount > 0 || localTurnCount > 0)) {
+      return;
+    }
+
     const modelLookup = new Map(models.map(model => [model.id, { name: model.name, provider: model.provider }]));
     debateSession.hydrateFromSession(sessionDetailsQuery.data, modelLookup);
 
@@ -321,7 +339,13 @@ export default function Debate() {
     debateSetup.setSelectedTopic('custom');
     debateSetup.setAdversarialLevel(sessionDetailsQuery.data.adversarialLevel);
     debateSetup.setShowSetup(false);
-  }, [sessionDetailsQuery.data, models]);
+  }, [
+    sessionDetailsQuery.data,
+    models,
+    debateSession.debateSessionId,
+    debateSession.messages.length,
+    debateSession.turnHistory.length,
+  ]);
 
   useEffect(() => {
     if (!debateStreaming.responseId || !debateSession.debateSessionId) return;

--- a/docs/2025-10-19-plan-debate-regression.md
+++ b/docs/2025-10-19-plan-debate-regression.md
@@ -1,0 +1,24 @@
+# Debate Regression Stabilization Plan
+
+## Goal
+Document the investigation and remediation steps for the debate view regression that reopens the setup panel and loses active transcript data after starting a session.
+
+## Current Understanding
+- Regression surfaces immediately after starting a fresh debate session.
+- UI flashes back to the setup state because the client transcript is cleared while the stream is still running.
+- Likely triggered by hydration logic that overwrites local state with stale server responses when the persistence layer has not caught up.
+
+## Investigation Tasks
+- [ ] Trace `useDebateSession.hydrateFromSession` to confirm when it resets local message state.
+- [ ] Inspect the debate page effect that triggers hydration on `sessionDetailsQuery` completion for ordering/race issues.
+- [ ] Verify how many turns are returned from `/api/debate/session/:id` while the first streaming response is in flight.
+
+## Remediation Tasks
+- [ ] Guard hydration so stale or empty payloads cannot clobber an active transcript.
+- [ ] Preserve existing jury annotations and response tracking when the server payload is behind the client state.
+- [ ] Regression test by simulating sequential hydration events to ensure the transcript remains visible.
+
+## Validation
+- Confirm the setup panel stays collapsed during an active debate run even while background refetches occur.
+- Ensure resumed sessions with real turn history still hydrate correctly.
+- Run the TypeScript type checker to catch structural issues introduced by the fix.


### PR DESCRIPTION
## Summary
- guard debate session hydration so stale payloads cannot clear the active transcript mid-stream
- preserve debate session response tracking when the server turn list is empty to avoid setup panel regression
- record the remediation plan and changelog entry for the hydration fix

## Testing
- npm run check *(fails: missing `@types/node` and `vite/client` type definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f46094c1cc8326b5135baefe207746