### PR TITLE
Fix debate hydration reset guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 <!--
  * Author: GPT-5 Codex
- * Date: 2025-10-19 00:34 UTC
+ * Date: 2025-10-21 02:52 UTC
  * PURPOSE: Maintain a human-readable history of notable changes for releases and audits.
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
+
+## [Version 0.4.21] - 2025-10-21 02:52 UTC
+
+### Fixed
+- **Debate Hydration Reset:** Clear the cached hydration signature whenever the active debate session resets or changes so reselections always repopulate transcripts.
 
 ## [Version 0.4.20] - 2025-10-21 02:40 UTC
 

--- a/client/src/pages/debate.tsx
+++ b/client/src/pages/debate.tsx
@@ -1,6 +1,6 @@
 /*
  * Author: gpt-5-codex
- * Date: 2025-02-14 00:12 UTC
+ * Date: 2025-10-21 02:52 UTC
  * PURPOSE: Orchestrate debate mode, hydrate persisted history, manage streaming, and ensure setup defaults select a valid topic.
  * SRP/DRY check: Pass - Component composes specialized hooks/services without overlapping their responsibilities.
  */
@@ -45,6 +45,7 @@ export default function Debate() {
   const { toast } = useToast();
   const chatEndRef = useRef<HTMLDivElement>(null);
   const lastHydratedSignatureRef = useRef<string | null>(null);
+  const lastDebateSessionIdRef = useRef<string | null>(null);
 
   const debateSetup = useDebateSetup();
   const debateSession = useDebateSession();
@@ -314,6 +315,15 @@ export default function Debate() {
     debateSetup.model2Config.enableReasoning,
     debateSetup.model2Config.enableReasoning
   ]);
+
+  useEffect(() => {
+    const currentSessionId = debateSession.debateSessionId ?? null;
+
+    if (lastDebateSessionIdRef.current !== currentSessionId) {
+      lastHydratedSignatureRef.current = null;
+      lastDebateSessionIdRef.current = currentSessionId;
+    }
+  }, [debateSession.debateSessionId]);
 
   useEffect(() => {
     if (!sessionDetailsQuery.data || models.length === 0) return;

--- a/docs/2025-10-21-plan-debate-hydration-reset.md
+++ b/docs/2025-10-21-plan-debate-hydration-reset.md
@@ -1,0 +1,22 @@
+<!--
+ * Author: gpt-5-codex
+ * Date: 2025-10-21 02:52 UTC
+ * PURPOSE: Document the plan and goals for clearing stale hydration signatures when debate sessions reset or switch.
+ * SRP/DRY check: Pass - planning notes for this fix live in a single task-specific file.
+-->
+
+# Debate Hydration Signature Reset Plan
+
+## Goal
+Restore debate transcript hydration when a user resets a session and reselects the same history entry by ensuring cached hydration signatures are cleared appropriately.
+
+## Context
+- `client/src/pages/debate.tsx` introduced `lastHydratedSignatureRef` to prevent redundant hydration.
+- Resetting a debate sets `debateSessionId` to `null` before users re-open a historical session, causing the signature check to block rehydration.
+- We need to clear the cached signature whenever the tracked session changes or resets to avoid stale guard values.
+
+## Tasks
+1. Inspect `debateSession.resetSession()` behavior to confirm when `debateSessionId` transitions to `null` and how selections propagate.
+2. Update the debate page effect logic to clear `lastHydratedSignatureRef` when the active session identifier changes, avoiding redundant hydration while still preventing loops.
+3. Verify TypeScript linting and interactions compile locally after the change.
+4. Update `CHANGELOG.md` with a new entry summarizing the bugfix.


### PR DESCRIPTION
## Summary
- clear the cached debate hydration signature whenever the selected session id changes so resets and reselections rehydrate correctly
- record the task plan for the hydration reset change and document the fix in the changelog

## Testing
- npm run check *(fails: Cannot find type definition file for 'node' / 'vite/client'; dependency installation is blocked in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f6f54e9cb08326aa01de071fea6e21