### PR TITLE
Fix debate session bootstrap for Postgres deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 <!--
  * Author: GPT-5 Codex
- * Date: 2025-10-21 02:52 UTC
+ * Date: 2025-10-21 03:33 UTC
  * PURPOSE: Maintain a human-readable history of notable changes for releases and audits.
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
+
+## [Version 0.4.22] - 2025-10-21 03:33 UTC
+
+### Fixed
+- **Debate Session Bootstrap:** Add the `debate_sessions` table definition to `DatabaseManager.ensureTablesExist` so PostgreSQL
+  environments create the persistence schema and debate streams can start new sessions successfully.
 
 ## [Version 0.4.21] - 2025-10-21 02:52 UTC
 

--- a/docs/2025-10-21-plan-debate-session-table-fix.md
+++ b/docs/2025-10-21-plan-debate-session-table-fix.md
@@ -1,0 +1,19 @@
+<!--
+ * Author: gpt-5-codex
+ * Date: 2025-10-21 03:33 UTC
+ * PURPOSE: Capture the remediation plan for debate session creation failures caused by missing database bootstrap.
+ * SRP/DRY check: Pass - Dedicated planning note for this regression fix.
+-->
+# Plan: Restore Debate Session Bootstrap
+
+## Goal
+Ensure PostgreSQL deployments provision the `debate_sessions` table so new debates can initialize successfully when persistence is enabled.
+
+## Tasks
+1. Extend `DatabaseManager.ensureTablesExist` to create the `debate_sessions` table with JSON columns and timestamp defaults mirroring `shared/schema.ts`.
+2. Verify the legacy fallback in `server/db.ts` already defines the table so no further changes are required there.
+3. Update `CHANGELOG.md` with a new version entry documenting the regression fix.
+
+## Validation
+- Static review of the SQL definition to confirm column names/types match the Drizzle schema.
+- Rely on the existing storage layer tests/utilities since automated build tooling is unavailable in this environment.

--- a/server/database-manager.ts
+++ b/server/database-manager.ts
@@ -198,7 +198,23 @@ export class DatabaseManager {
           "updated_at" timestamp DEFAULT now()
         );
       `);
-      
+
+      await this.db.execute(`
+        CREATE TABLE IF NOT EXISTS "debate_sessions" (
+          "id" text PRIMARY KEY,
+          "topic_text" text NOT NULL,
+          "model1_id" text NOT NULL,
+          "model2_id" text NOT NULL,
+          "adversarial_level" integer NOT NULL,
+          "turn_history" jsonb NOT NULL DEFAULT '[]'::jsonb,
+          "model1_response_ids" jsonb NOT NULL DEFAULT '[]'::jsonb,
+          "model2_response_ids" jsonb NOT NULL DEFAULT '[]'::jsonb,
+          "total_cost" numeric DEFAULT '0',
+          "created_at" timestamp DEFAULT now(),
+          "updated_at" timestamp DEFAULT now()
+        );
+      `);
+
       console.log("✅ Database tables ensured");
     } catch (error) {
       console.warn("⚠️ Could not ensure tables exist:", (error as Error).message);


### PR DESCRIPTION
## Summary
- add the `debate_sessions` bootstrap SQL to `DatabaseManager.ensureTablesExist` so Postgres-backed installs create the table
- capture the remediation plan for the regression in `docs/2025-10-21-plan-debate-session-table-fix.md`
- document the fix in the changelog with a new 0.4.22 entry

## Testing
- npm test -- debate-handshake *(fails: vite not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6fcab062c8326bbc128216ec3c29a