### PR TITLE
Guard debate hydration against stale sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
  * SRP/DRY check: Pass - changelog content is centralized in one file with no duplication across docs.
 -->
 
+## [Version 0.4.23] - 2025-10-22 00:01 UTC
+
+### Fixed
+- **Debate Hydration Guard:** Require an active session identifier match before hydrating stored debate transcripts so clearing state for a new session no longer resurrects the previous transcript.
+
 ## [Version 0.4.22] - 2025-10-21 04:30 UTC
 
 ### Fixed

--- a/client/src/pages/debate.tsx
+++ b/client/src/pages/debate.tsx
@@ -1,7 +1,7 @@
 /*
  * Author: gpt-5-codex
- * Date: 2025-10-21 04:30 UTC
- * PURPOSE: Orchestrate debate mode, hydrate persisted history, manage streaming, and ensure setup defaults select a valid topic.
+ * Date: 2025-10-22 00:01 UTC
+ * PURPOSE: Orchestrate debate mode, hydrate persisted history, manage streaming, and ensure setup defaults select a valid topic while guarding against stale session hydration after resets.
  * SRP/DRY check: Pass - Component composes specialized hooks/services without overlapping their responsibilities.
  */
 
@@ -326,12 +326,21 @@ export default function Debate() {
   }, [debateSession.debateSessionId]);
 
   useEffect(() => {
+    const activeSessionId = debateSession.debateSessionId;
+    if (!activeSessionId) {
+      return;
+    }
+
     if (!sessionDetailsQuery.data || models.length === 0) return;
+
+    if (sessionDetailsQuery.data.id !== activeSessionId) {
+      return;
+    }
 
     const incomingTurnCount = sessionDetailsQuery.data.turnHistory?.length ?? 0;
     const localMessageCount = debateSession.messages.length;
     const localTurnCount = debateSession.turnHistory.length;
-    const isSameSession = sessionDetailsQuery.data.id === debateSession.debateSessionId;
+    const isSameSession = sessionDetailsQuery.data.id === activeSessionId;
     const latestTurn = incomingTurnCount > 0
       ? sessionDetailsQuery.data.turnHistory?.[incomingTurnCount - 1]
       : null;

--- a/docs/2025-10-22-plan-debate-session-guard.md
+++ b/docs/2025-10-22-plan-debate-session-guard.md
@@ -1,0 +1,30 @@
+<!--
+ * Author: gpt-5-codex
+ * Date: 2025-10-22 00:01 UTC
+ * PURPOSE: Outline the fix for the debate session hydration regression that repopulates cleared state when
+ *          the cached session detail query still holds stale data.
+ * SRP/DRY check: Pass - Focused troubleshooting note specific to the debate session hydration guard.
+ -->
+# Debate Session Hydration Guard Plan
+
+## Goal
+Prevent stale debate session payloads from rehydrating the UI after the user resets or starts a new session.
+
+## Context
+- `client/src/pages/debate.tsx` clears debate state before starting a new session, but the React Query cache still
+  exposes the previous session payload.
+- The hydration effect currently runs as long as session detail data exists, regardless of whether the data matches
+  the active session identifier.
+- This causes the cleared state to instantly repopulate with the old transcript, blocking new session bootstrapping.
+
+## Tasks
+1. Update the hydration `useEffect` guard in `client/src/pages/debate.tsx` to require a non-null active session ID
+   and a matching session identifier before calling `hydrateFromSession`.
+2. Retain the existing signature comparison logic so legitimate updates still hydrate when the server turn history
+   advances.
+3. Refresh the changelog with a new version entry documenting the regression fix.
+
+## Verification
+- Reset the debate or start a fresh session: the transcript should remain empty until the new stream begins.
+- Reopen a saved session from the history drawer: hydration should occur once the selected session data loads.
+- Run targeted TypeScript checks (`npm run check`) when dependencies are available to confirm type safety.


### PR DESCRIPTION
## Summary
- add a plan document capturing the debate session hydration guard investigation
- guard the debate session hydration effect so only the active session identifier rehydrates the UI
- record the regression fix in the changelog

## Testing
- npm test -- --run tests/server/debate-handshake.test.ts *(fails: local vite binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f81ca881ec8326ba1f908f56d9f530